### PR TITLE
Add gen/otlp/ freshness CI check and .gitattributes merge strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Generated code — always keep our side on merge conflicts.
+gen/** merge=ours

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           go-version-file: go.mod
       - run: make generate-ours
+      - run: git add gen/ --intent-to-add
       - name: Check gen/otlp/ is up to date
         run: |
           if ! git diff --exit-code gen/otlp/; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,13 @@ jobs:
   build-test:
     name: Build & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: go.mod
@@ -29,10 +32,13 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: go.mod
@@ -41,11 +47,35 @@ jobs:
   fuzz:
     name: Fuzz
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
           go-version-file: go.mod
       - run: make fuzz
+
+  generate-check:
+    name: Generated Code Freshness
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: go.mod
+      - run: make generate-ours
+      - name: Check gen/otlp/ is up to date
+        run: |
+          if ! git diff --exit-code gen/otlp/; then
+            echo "::error::gen/otlp/ is stale. Run 'make generate-ours' and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Add `generate-check` CI job that re-runs `make generate-ours` and fails if `gen/otlp/` has uncommitted diffs (catches stale generated code)
- Add `.gitattributes` with `gen/** merge=ours` so merge conflicts in generated files auto-resolve
- Harden all CI jobs with `timeout-minutes: 10` and `persist-credentials: false`

## Test plan
- [ ] `generate-check` job passes on this PR
- [ ] Existing `build-test`, `lint`, and `fuzz` jobs still pass
- [ ] Verify freshness check catches stale files: modify a proto, push without regenerating, confirm CI fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)