### PR TITLE
Add recursion depth limit to generated Unmarshal

### DIFF
--- a/compiler/generator/emit_unmarshal.go
+++ b/compiler/generator/emit_unmarshal.go
@@ -122,7 +122,16 @@ func (fg *FileGenerator) emitUnmarshal(md protoreflect.MessageDescriptor) {
 	fg.imports.addImport("google.golang.org/protobuf/encoding/protowire", "")
 	fg.imports.addImport("fmt", "")
 
+	// Public wrapper that starts depth tracking at zero.
 	fmt.Fprintf(fg.body, "func (m *%s) Unmarshal(b []byte) error {\n", name)
+	fmt.Fprintf(fg.body, "\treturn m.unmarshal(b, 0)\n")
+	fmt.Fprintf(fg.body, "}\n\n")
+
+	// Private implementation with recursion depth limit.
+	fmt.Fprintf(fg.body, "func (m *%s) unmarshal(b []byte, depth int) error {\n", name)
+	fmt.Fprintf(fg.body, "\tif depth > maxUnmarshalDepth {\n")
+	fmt.Fprintf(fg.body, "\t\treturn fmt.Errorf(\"exceeded max recursion depth\")\n")
+	fmt.Fprintf(fg.body, "\t}\n")
 	fg.emitPreScan(md)
 	fmt.Fprintf(fg.body, "\tfor len(b) > 0 {\n")
 	fmt.Fprintf(fg.body, "\t\tnum, typ, tagLen := protowire.ConsumeTag(b)\n")
@@ -303,7 +312,7 @@ func (fg *FileGenerator) emitSingularFieldUnmarshal(goName string, fd protorefle
 		msgType := fg.imports.goMessageType(fd.Message())
 		_ = msgType
 		fg.emitConsumeBytes()
-		fmt.Fprintf(fg.body, "\t\t\tif err := %s.Unmarshal(v); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n", access)
+		fg.emitUnmarshalCall(access, fd.Message())
 		fg.emitAdvanceBytes()
 	}
 }
@@ -407,7 +416,8 @@ func (fg *FileGenerator) emitRepeatedFieldUnmarshal(goName string, fd protorefle
 		msgType := fg.imports.goSingularType(fd)
 		fg.emitConsumeBytes()
 		fmt.Fprintf(fg.body, "\t\t\t%s = append(%s, %s{})\n", access, access, msgType)
-		fmt.Fprintf(fg.body, "\t\t\tif err := %s[len(%s)-1].Unmarshal(v); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n", access, access)
+		sliceAccess := fmt.Sprintf("%s[len(%s)-1]", access, access)
+		fg.emitUnmarshalCall(sliceAccess, fd.Message())
 		fg.emitAdvanceBytes()
 
 	case kind == protoreflect.StringKind:
@@ -639,7 +649,7 @@ func (fg *FileGenerator) emitOneofFieldUnmarshal(md protoreflect.MessageDescript
 		fg.emitConsumeBytes()
 		msgType := fg.imports.goSingularType(fd)
 		fmt.Fprintf(fg.body, "\t\t\tvar msg %s\n", msgType)
-		fmt.Fprintf(fg.body, "\t\t\tif err := msg.Unmarshal(v); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n")
+		fg.emitUnmarshalCall("msg", fd.Message())
 		fmt.Fprintf(fg.body, "\t\t\tm.%s = &%s{%s: msg}\n", ooFieldName, variantName, fieldName)
 		fg.emitAdvanceBytes()
 	}
@@ -674,4 +684,17 @@ func (fg *FileGenerator) emitConsumeString() {
 
 func (fg *FileGenerator) emitAdvanceBytes() {
 	fmt.Fprintf(fg.body, "\t\t\tb = b[n:]\n")
+}
+
+// emitUnmarshalCall emits the correct recursive unmarshal call for a message
+// field. Same-package types use the private unmarshal(b, depth+1) to propagate
+// the depth counter; cross-package types use the public Unmarshal(b) because
+// the private method is not exported.
+func (fg *FileGenerator) emitUnmarshalCall(access string, md protoreflect.MessageDescriptor) {
+	msgPkg := string(md.ParentFile().Package())
+	if msgPkg == fg.imports.selfPkg {
+		fmt.Fprintf(fg.body, "\t\t\tif err := %s.unmarshal(v, depth+1); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n", access)
+	} else {
+		fmt.Fprintf(fg.body, "\t\t\tif err := %s.Unmarshal(v); err != nil {\n\t\t\t\treturn err\n\t\t\t}\n", access)
+	}
 }

--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -205,7 +205,8 @@ func (fg *FileGenerator) emitMarshalMethods(md protoreflect.MessageDescriptor) {
 }
 
 func (fg *FileGenerator) emitAllUnmarshalMethods(fd protoreflect.FileDescriptor) {
-	// Emit the skipField helper once per package
+	// Emit the max recursion depth constant and skipField helper once per file.
+	fmt.Fprintf(fg.body, "const maxUnmarshalDepth = 10000\n\n")
 	fg.emitSkipFieldHelper()
 	for i := 0; i < fd.Messages().Len(); i++ {
 		fg.emitUnmarshalMethods(fd.Messages().Get(i))

--- a/gen/otlp/common/v1/common.go
+++ b/gen/otlp/common/v1/common.go
@@ -487,6 +487,8 @@ func (m *EntityRef) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+const maxUnmarshalDepth = 10000
+
 func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) {
 	switch typ {
 	case protowire.VarintType:
@@ -523,6 +525,13 @@ func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) 
 }
 
 func (m *AnyValue) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *AnyValue) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -604,7 +613,7 @@ func (m *AnyValue) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			var msg ArrayValue
-			if err := msg.Unmarshal(v); err != nil {
+			if err := msg.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			m.Value = &AnyValue_ArrayValue{ArrayValue: msg}
@@ -623,7 +632,7 @@ func (m *AnyValue) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			var msg KeyValueList
-			if err := msg.Unmarshal(v); err != nil {
+			if err := msg.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			m.Value = &AnyValue_KvlistValue{KvlistValue: msg}
@@ -670,6 +679,13 @@ func (m *AnyValue) Unmarshal(b []byte) error {
 }
 
 func (m *ArrayValue) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ArrayValue) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -726,7 +742,7 @@ func (m *ArrayValue) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Values = append(m.Values, AnyValue{})
-			if err := m.Values[len(m.Values)-1].Unmarshal(v); err != nil {
+			if err := m.Values[len(m.Values)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -742,6 +758,13 @@ func (m *ArrayValue) Unmarshal(b []byte) error {
 }
 
 func (m *KeyValueList) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *KeyValueList) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -798,7 +821,7 @@ func (m *KeyValueList) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Values = append(m.Values, KeyValue{})
-			if err := m.Values[len(m.Values)-1].Unmarshal(v); err != nil {
+			if err := m.Values[len(m.Values)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -814,6 +837,13 @@ func (m *KeyValueList) Unmarshal(b []byte) error {
 }
 
 func (m *KeyValue) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *KeyValue) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -849,7 +879,7 @@ func (m *KeyValue) Unmarshal(b []byte) error {
 			if n < 0 {
 				return fmt.Errorf("invalid bytes")
 			}
-			if err := m.Value.Unmarshal(v); err != nil {
+			if err := m.Value.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -880,6 +910,13 @@ func (m *KeyValue) Unmarshal(b []byte) error {
 }
 
 func (m *InstrumentationScope) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *InstrumentationScope) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field3count int
@@ -966,7 +1003,7 @@ func (m *InstrumentationScope) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Attributes = append(m.Attributes, KeyValue{})
-			if err := m.Attributes[len(m.Attributes)-1].Unmarshal(v); err != nil {
+			if err := m.Attributes[len(m.Attributes)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -997,6 +1034,13 @@ func (m *InstrumentationScope) Unmarshal(b []byte) error {
 }
 
 func (m *EntityRef) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *EntityRef) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field3count int

--- a/gen/otlp/logs/v1/logs.go
+++ b/gen/otlp/logs/v1/logs.go
@@ -404,6 +404,8 @@ func (m *LogRecord) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+const maxUnmarshalDepth = 10000
+
 func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) {
 	switch typ {
 	case protowire.VarintType:
@@ -440,6 +442,13 @@ func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) 
 }
 
 func (m *LogsData) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *LogsData) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -496,7 +505,7 @@ func (m *LogsData) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.ResourceLogs = append(m.ResourceLogs, ResourceLogs{})
-			if err := m.ResourceLogs[len(m.ResourceLogs)-1].Unmarshal(v); err != nil {
+			if err := m.ResourceLogs[len(m.ResourceLogs)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -512,6 +521,13 @@ func (m *LogsData) Unmarshal(b []byte) error {
 }
 
 func (m *ResourceLogs) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ResourceLogs) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field2count int
@@ -585,7 +601,7 @@ func (m *ResourceLogs) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.ScopeLogs = append(m.ScopeLogs, ScopeLogs{})
-			if err := m.ScopeLogs[len(m.ScopeLogs)-1].Unmarshal(v); err != nil {
+			if err := m.ScopeLogs[len(m.ScopeLogs)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -616,6 +632,13 @@ func (m *ResourceLogs) Unmarshal(b []byte) error {
 }
 
 func (m *ScopeLogs) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ScopeLogs) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field2count int
@@ -689,7 +712,7 @@ func (m *ScopeLogs) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.LogRecords = append(m.LogRecords, LogRecord{})
-			if err := m.LogRecords[len(m.LogRecords)-1].Unmarshal(v); err != nil {
+			if err := m.LogRecords[len(m.LogRecords)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -720,6 +743,13 @@ func (m *ScopeLogs) Unmarshal(b []byte) error {
 }
 
 func (m *LogRecord) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *LogRecord) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field6count int

--- a/gen/otlp/metrics/v1/metrics.go
+++ b/gen/otlp/metrics/v1/metrics.go
@@ -1491,6 +1491,8 @@ func (m *Exemplar) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+const maxUnmarshalDepth = 10000
+
 func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) {
 	switch typ {
 	case protowire.VarintType:
@@ -1527,6 +1529,13 @@ func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) 
 }
 
 func (m *MetricsData) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *MetricsData) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -1583,7 +1592,7 @@ func (m *MetricsData) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.ResourceMetrics = append(m.ResourceMetrics, ResourceMetrics{})
-			if err := m.ResourceMetrics[len(m.ResourceMetrics)-1].Unmarshal(v); err != nil {
+			if err := m.ResourceMetrics[len(m.ResourceMetrics)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1599,6 +1608,13 @@ func (m *MetricsData) Unmarshal(b []byte) error {
 }
 
 func (m *ResourceMetrics) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ResourceMetrics) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field2count int
@@ -1672,7 +1688,7 @@ func (m *ResourceMetrics) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.ScopeMetrics = append(m.ScopeMetrics, ScopeMetrics{})
-			if err := m.ScopeMetrics[len(m.ScopeMetrics)-1].Unmarshal(v); err != nil {
+			if err := m.ScopeMetrics[len(m.ScopeMetrics)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1703,6 +1719,13 @@ func (m *ResourceMetrics) Unmarshal(b []byte) error {
 }
 
 func (m *ScopeMetrics) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ScopeMetrics) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field2count int
@@ -1776,7 +1799,7 @@ func (m *ScopeMetrics) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Metrics = append(m.Metrics, Metric{})
-			if err := m.Metrics[len(m.Metrics)-1].Unmarshal(v); err != nil {
+			if err := m.Metrics[len(m.Metrics)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1807,6 +1830,13 @@ func (m *ScopeMetrics) Unmarshal(b []byte) error {
 }
 
 func (m *Metric) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Metric) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field12count int
@@ -1908,7 +1938,7 @@ func (m *Metric) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			var msg Gauge
-			if err := msg.Unmarshal(v); err != nil {
+			if err := msg.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			m.Data = &Metric_Gauge{Gauge: msg}
@@ -1927,7 +1957,7 @@ func (m *Metric) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			var msg Sum
-			if err := msg.Unmarshal(v); err != nil {
+			if err := msg.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			m.Data = &Metric_Sum{Sum: msg}
@@ -1946,7 +1976,7 @@ func (m *Metric) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			var msg Histogram
-			if err := msg.Unmarshal(v); err != nil {
+			if err := msg.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			m.Data = &Metric_Histogram{Histogram: msg}
@@ -1965,7 +1995,7 @@ func (m *Metric) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			var msg ExponentialHistogram
-			if err := msg.Unmarshal(v); err != nil {
+			if err := msg.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			m.Data = &Metric_ExponentialHistogram{ExponentialHistogram: msg}
@@ -1984,7 +2014,7 @@ func (m *Metric) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			var msg Summary
-			if err := msg.Unmarshal(v); err != nil {
+			if err := msg.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			m.Data = &Metric_Summary{Summary: msg}
@@ -2019,6 +2049,13 @@ func (m *Metric) Unmarshal(b []byte) error {
 }
 
 func (m *Gauge) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Gauge) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -2075,7 +2112,7 @@ func (m *Gauge) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.DataPoints = append(m.DataPoints, NumberDataPoint{})
-			if err := m.DataPoints[len(m.DataPoints)-1].Unmarshal(v); err != nil {
+			if err := m.DataPoints[len(m.DataPoints)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -2091,6 +2128,13 @@ func (m *Gauge) Unmarshal(b []byte) error {
 }
 
 func (m *Sum) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Sum) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -2147,7 +2191,7 @@ func (m *Sum) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.DataPoints = append(m.DataPoints, NumberDataPoint{})
-			if err := m.DataPoints[len(m.DataPoints)-1].Unmarshal(v); err != nil {
+			if err := m.DataPoints[len(m.DataPoints)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -2193,6 +2237,13 @@ func (m *Sum) Unmarshal(b []byte) error {
 }
 
 func (m *Histogram) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Histogram) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -2249,7 +2300,7 @@ func (m *Histogram) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.DataPoints = append(m.DataPoints, HistogramDataPoint{})
-			if err := m.DataPoints[len(m.DataPoints)-1].Unmarshal(v); err != nil {
+			if err := m.DataPoints[len(m.DataPoints)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -2280,6 +2331,13 @@ func (m *Histogram) Unmarshal(b []byte) error {
 }
 
 func (m *ExponentialHistogram) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ExponentialHistogram) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -2336,7 +2394,7 @@ func (m *ExponentialHistogram) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.DataPoints = append(m.DataPoints, ExponentialHistogramDataPoint{})
-			if err := m.DataPoints[len(m.DataPoints)-1].Unmarshal(v); err != nil {
+			if err := m.DataPoints[len(m.DataPoints)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -2367,6 +2425,13 @@ func (m *ExponentialHistogram) Unmarshal(b []byte) error {
 }
 
 func (m *Summary) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Summary) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -2423,7 +2488,7 @@ func (m *Summary) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.DataPoints = append(m.DataPoints, SummaryDataPoint{})
-			if err := m.DataPoints[len(m.DataPoints)-1].Unmarshal(v); err != nil {
+			if err := m.DataPoints[len(m.DataPoints)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -2439,6 +2504,13 @@ func (m *Summary) Unmarshal(b []byte) error {
 }
 
 func (m *NumberDataPoint) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *NumberDataPoint) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field7count int
@@ -2579,7 +2651,7 @@ func (m *NumberDataPoint) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Exemplars = append(m.Exemplars, Exemplar{})
-			if err := m.Exemplars[len(m.Exemplars)-1].Unmarshal(v); err != nil {
+			if err := m.Exemplars[len(m.Exemplars)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -2610,6 +2682,13 @@ func (m *NumberDataPoint) Unmarshal(b []byte) error {
 }
 
 func (m *HistogramDataPoint) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *HistogramDataPoint) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field9count int
@@ -2815,7 +2894,7 @@ func (m *HistogramDataPoint) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Exemplars = append(m.Exemplars, Exemplar{})
-			if err := m.Exemplars[len(m.Exemplars)-1].Unmarshal(v); err != nil {
+			if err := m.Exemplars[len(m.Exemplars)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -2878,6 +2957,13 @@ func (m *HistogramDataPoint) Unmarshal(b []byte) error {
 }
 
 func (m *ExponentialHistogramDataPoint_Buckets) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ExponentialHistogramDataPoint_Buckets) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -2950,6 +3036,13 @@ func (m *ExponentialHistogramDataPoint_Buckets) Unmarshal(b []byte) error {
 }
 
 func (m *ExponentialHistogramDataPoint) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ExponentialHistogramDataPoint) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -3120,7 +3213,7 @@ func (m *ExponentialHistogramDataPoint) Unmarshal(b []byte) error {
 			if n < 0 {
 				return fmt.Errorf("invalid bytes")
 			}
-			if err := m.Positive.Unmarshal(v); err != nil {
+			if err := m.Positive.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -3137,7 +3230,7 @@ func (m *ExponentialHistogramDataPoint) Unmarshal(b []byte) error {
 			if n < 0 {
 				return fmt.Errorf("invalid bytes")
 			}
-			if err := m.Negative.Unmarshal(v); err != nil {
+			if err := m.Negative.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -3170,7 +3263,7 @@ func (m *ExponentialHistogramDataPoint) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Exemplars = append(m.Exemplars, Exemplar{})
-			if err := m.Exemplars[len(m.Exemplars)-1].Unmarshal(v); err != nil {
+			if err := m.Exemplars[len(m.Exemplars)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -3233,6 +3326,13 @@ func (m *ExponentialHistogramDataPoint) Unmarshal(b []byte) error {
 }
 
 func (m *SummaryDataPoint_ValueAtQuantile) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *SummaryDataPoint_ValueAtQuantile) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -3282,6 +3382,13 @@ func (m *SummaryDataPoint_ValueAtQuantile) Unmarshal(b []byte) error {
 }
 
 func (m *SummaryDataPoint) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *SummaryDataPoint) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field7count int
@@ -3422,7 +3529,7 @@ func (m *SummaryDataPoint) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.QuantileValues = append(m.QuantileValues, SummaryDataPoint_ValueAtQuantile{})
-			if err := m.QuantileValues[len(m.QuantileValues)-1].Unmarshal(v); err != nil {
+			if err := m.QuantileValues[len(m.QuantileValues)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -3453,6 +3560,13 @@ func (m *SummaryDataPoint) Unmarshal(b []byte) error {
 }
 
 func (m *Exemplar) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Exemplar) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field7count int

--- a/gen/otlp/profiles/v1development/profiles.go
+++ b/gen/otlp/profiles/v1development/profiles.go
@@ -1143,6 +1143,8 @@ func (m *KeyValueAndUnit) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+const maxUnmarshalDepth = 10000
+
 func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) {
 	switch typ {
 	case protowire.VarintType:
@@ -1179,6 +1181,13 @@ func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) 
 }
 
 func (m *ProfilesDictionary) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ProfilesDictionary) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -1271,7 +1280,7 @@ func (m *ProfilesDictionary) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.MappingTable = append(m.MappingTable, Mapping{})
-			if err := m.MappingTable[len(m.MappingTable)-1].Unmarshal(v); err != nil {
+			if err := m.MappingTable[len(m.MappingTable)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1289,7 +1298,7 @@ func (m *ProfilesDictionary) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.LocationTable = append(m.LocationTable, Location{})
-			if err := m.LocationTable[len(m.LocationTable)-1].Unmarshal(v); err != nil {
+			if err := m.LocationTable[len(m.LocationTable)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1307,7 +1316,7 @@ func (m *ProfilesDictionary) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.FunctionTable = append(m.FunctionTable, Function{})
-			if err := m.FunctionTable[len(m.FunctionTable)-1].Unmarshal(v); err != nil {
+			if err := m.FunctionTable[len(m.FunctionTable)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1325,7 +1334,7 @@ func (m *ProfilesDictionary) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.LinkTable = append(m.LinkTable, Link{})
-			if err := m.LinkTable[len(m.LinkTable)-1].Unmarshal(v); err != nil {
+			if err := m.LinkTable[len(m.LinkTable)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1358,7 +1367,7 @@ func (m *ProfilesDictionary) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.AttributeTable = append(m.AttributeTable, KeyValueAndUnit{})
-			if err := m.AttributeTable[len(m.AttributeTable)-1].Unmarshal(v); err != nil {
+			if err := m.AttributeTable[len(m.AttributeTable)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1376,7 +1385,7 @@ func (m *ProfilesDictionary) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.StackTable = append(m.StackTable, Stack{})
-			if err := m.StackTable[len(m.StackTable)-1].Unmarshal(v); err != nil {
+			if err := m.StackTable[len(m.StackTable)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1392,6 +1401,13 @@ func (m *ProfilesDictionary) Unmarshal(b []byte) error {
 }
 
 func (m *ProfilesData) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ProfilesData) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -1448,7 +1464,7 @@ func (m *ProfilesData) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.ResourceProfiles = append(m.ResourceProfiles, ResourceProfiles{})
-			if err := m.ResourceProfiles[len(m.ResourceProfiles)-1].Unmarshal(v); err != nil {
+			if err := m.ResourceProfiles[len(m.ResourceProfiles)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1465,7 +1481,7 @@ func (m *ProfilesData) Unmarshal(b []byte) error {
 			if n < 0 {
 				return fmt.Errorf("invalid bytes")
 			}
-			if err := m.Dictionary.Unmarshal(v); err != nil {
+			if err := m.Dictionary.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1481,6 +1497,13 @@ func (m *ProfilesData) Unmarshal(b []byte) error {
 }
 
 func (m *ResourceProfiles) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ResourceProfiles) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field2count int
@@ -1554,7 +1577,7 @@ func (m *ResourceProfiles) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.ScopeProfiles = append(m.ScopeProfiles, ScopeProfiles{})
-			if err := m.ScopeProfiles[len(m.ScopeProfiles)-1].Unmarshal(v); err != nil {
+			if err := m.ScopeProfiles[len(m.ScopeProfiles)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1585,6 +1608,13 @@ func (m *ResourceProfiles) Unmarshal(b []byte) error {
 }
 
 func (m *ScopeProfiles) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ScopeProfiles) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field2count int
@@ -1658,7 +1688,7 @@ func (m *ScopeProfiles) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Profiles = append(m.Profiles, Profile{})
-			if err := m.Profiles[len(m.Profiles)-1].Unmarshal(v); err != nil {
+			if err := m.Profiles[len(m.Profiles)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1689,6 +1719,13 @@ func (m *ScopeProfiles) Unmarshal(b []byte) error {
 }
 
 func (m *Profile) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Profile) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field2count int
@@ -1744,7 +1781,7 @@ func (m *Profile) Unmarshal(b []byte) error {
 			if n < 0 {
 				return fmt.Errorf("invalid bytes")
 			}
-			if err := m.SampleType.Unmarshal(v); err != nil {
+			if err := m.SampleType.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1762,7 +1799,7 @@ func (m *Profile) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Samples = append(m.Samples, Sample{})
-			if err := m.Samples[len(m.Samples)-1].Unmarshal(v); err != nil {
+			if err := m.Samples[len(m.Samples)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1809,7 +1846,7 @@ func (m *Profile) Unmarshal(b []byte) error {
 			if n < 0 {
 				return fmt.Errorf("invalid bytes")
 			}
-			if err := m.PeriodType.Unmarshal(v); err != nil {
+			if err := m.PeriodType.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1938,6 +1975,13 @@ func (m *Profile) Unmarshal(b []byte) error {
 }
 
 func (m *Link) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Link) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -1987,6 +2031,13 @@ func (m *Link) Unmarshal(b []byte) error {
 }
 
 func (m *ValueType) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ValueType) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -2036,6 +2087,13 @@ func (m *ValueType) Unmarshal(b []byte) error {
 }
 
 func (m *Sample) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Sample) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -2193,6 +2251,13 @@ func (m *Sample) Unmarshal(b []byte) error {
 }
 
 func (m *Mapping) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Mapping) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -2310,6 +2375,13 @@ func (m *Mapping) Unmarshal(b []byte) error {
 }
 
 func (m *Stack) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Stack) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -2367,6 +2439,13 @@ func (m *Stack) Unmarshal(b []byte) error {
 }
 
 func (m *Location) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Location) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field3count int
@@ -2453,7 +2532,7 @@ func (m *Location) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Lines = append(m.Lines, Line{})
-			if err := m.Lines[len(m.Lines)-1].Unmarshal(v); err != nil {
+			if err := m.Lines[len(m.Lines)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -2507,6 +2586,13 @@ func (m *Location) Unmarshal(b []byte) error {
 }
 
 func (m *Line) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Line) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -2571,6 +2657,13 @@ func (m *Line) Unmarshal(b []byte) error {
 }
 
 func (m *Function) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Function) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {
@@ -2650,6 +2743,13 @@ func (m *Function) Unmarshal(b []byte) error {
 }
 
 func (m *KeyValueAndUnit) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *KeyValueAndUnit) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {

--- a/gen/otlp/resource/v1/resource.go
+++ b/gen/otlp/resource/v1/resource.go
@@ -80,6 +80,8 @@ func (m *Resource) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+const maxUnmarshalDepth = 10000
+
 func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) {
 	switch typ {
 	case protowire.VarintType:
@@ -116,6 +118,13 @@ func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) 
 }
 
 func (m *Resource) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Resource) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int

--- a/gen/otlp/trace/v1/trace.go
+++ b/gen/otlp/trace/v1/trace.go
@@ -681,6 +681,8 @@ func (m *Status) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+const maxUnmarshalDepth = 10000
+
 func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) {
 	switch typ {
 	case protowire.VarintType:
@@ -717,6 +719,13 @@ func skipField(b []byte, num protowire.Number, typ protowire.Type) (int, error) 
 }
 
 func (m *TracesData) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *TracesData) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field1count int
@@ -773,7 +782,7 @@ func (m *TracesData) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.ResourceSpans = append(m.ResourceSpans, ResourceSpans{})
-			if err := m.ResourceSpans[len(m.ResourceSpans)-1].Unmarshal(v); err != nil {
+			if err := m.ResourceSpans[len(m.ResourceSpans)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -789,6 +798,13 @@ func (m *TracesData) Unmarshal(b []byte) error {
 }
 
 func (m *ResourceSpans) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ResourceSpans) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field2count int
@@ -862,7 +878,7 @@ func (m *ResourceSpans) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.ScopeSpans = append(m.ScopeSpans, ScopeSpans{})
-			if err := m.ScopeSpans[len(m.ScopeSpans)-1].Unmarshal(v); err != nil {
+			if err := m.ScopeSpans[len(m.ScopeSpans)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -893,6 +909,13 @@ func (m *ResourceSpans) Unmarshal(b []byte) error {
 }
 
 func (m *ScopeSpans) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *ScopeSpans) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field2count int
@@ -966,7 +989,7 @@ func (m *ScopeSpans) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Spans = append(m.Spans, Span{})
-			if err := m.Spans[len(m.Spans)-1].Unmarshal(v); err != nil {
+			if err := m.Spans[len(m.Spans)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -997,6 +1020,13 @@ func (m *ScopeSpans) Unmarshal(b []byte) error {
 }
 
 func (m *Span_Event) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Span_Event) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field3count int
@@ -1114,6 +1144,13 @@ func (m *Span_Event) Unmarshal(b []byte) error {
 }
 
 func (m *Span_Link) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Span_Link) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field4count int
@@ -1261,6 +1298,13 @@ func (m *Span_Link) Unmarshal(b []byte) error {
 }
 
 func (m *Span) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Span) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	if len(b) >= 256 {
 		tmp := b
 		var field9count int
@@ -1497,7 +1541,7 @@ func (m *Span) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Events = append(m.Events, Span_Event{})
-			if err := m.Events[len(m.Events)-1].Unmarshal(v); err != nil {
+			if err := m.Events[len(m.Events)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1530,7 +1574,7 @@ func (m *Span) Unmarshal(b []byte) error {
 				return fmt.Errorf("invalid bytes")
 			}
 			m.Links = append(m.Links, Span_Link{})
-			if err := m.Links[len(m.Links)-1].Unmarshal(v); err != nil {
+			if err := m.Links[len(m.Links)-1].unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1562,7 +1606,7 @@ func (m *Span) Unmarshal(b []byte) error {
 			if n < 0 {
 				return fmt.Errorf("invalid bytes")
 			}
-			if err := m.Status.Unmarshal(v); err != nil {
+			if err := m.Status.unmarshal(v, depth+1); err != nil {
 				return err
 			}
 			b = b[n:]
@@ -1578,6 +1622,13 @@ func (m *Span) Unmarshal(b []byte) error {
 }
 
 func (m *Status) Unmarshal(b []byte) error {
+	return m.unmarshal(b, 0)
+}
+
+func (m *Status) unmarshal(b []byte, depth int) error {
+	if depth > maxUnmarshalDepth {
+		return fmt.Errorf("exceeded max recursion depth")
+	}
 	for len(b) > 0 {
 		num, typ, tagLen := protowire.ConsumeTag(b)
 		if tagLen < 0 {

--- a/test/depth_limit_test.go
+++ b/test/depth_limit_test.go
@@ -1,0 +1,70 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+
+	commonv1 "wiresmith/gen/otlp/common/v1"
+)
+
+// buildNestedAnyValueBytes constructs wire-format bytes for an AnyValue nested
+// to the given depth via the AnyValue -> ArrayValue -> AnyValue cycle.
+// The innermost AnyValue holds a string "hello".
+func buildNestedAnyValueBytes(depth int) []byte {
+	// Innermost: AnyValue with string_value = "hello"
+	// Field 1 (string_value): tag(1, BytesType) + len + "hello"
+	inner := protowire.AppendTag(nil, 1, protowire.BytesType)
+	inner = protowire.AppendString(inner, "hello")
+
+	for i := 0; i < depth; i++ {
+		// Wrap inner AnyValue bytes in an ArrayValue.
+		// ArrayValue field 1 (repeated AnyValue): tag(1, BytesType) + len + inner
+		arrayValue := protowire.AppendTag(nil, 1, protowire.BytesType)
+		arrayValue = protowire.AppendBytes(arrayValue, inner)
+
+		// Wrap ArrayValue in an AnyValue.
+		// AnyValue field 5 (array_value): tag(5, BytesType) + len + arrayValue
+		anyValue := protowire.AppendTag(nil, 5, protowire.BytesType)
+		anyValue = protowire.AppendBytes(anyValue, arrayValue)
+
+		inner = anyValue
+	}
+
+	return inner
+}
+
+func TestUnmarshalDepthLimit(t *testing.T) {
+	t.Run("shallow nesting succeeds", func(t *testing.T) {
+		// 5 levels of nesting should unmarshal without error.
+		b := buildNestedAnyValueBytes(5)
+		var av commonv1.AnyValue
+		err := av.Unmarshal(b)
+		require.NoError(t, err)
+
+		// Verify the innermost value is accessible.
+		cur := &av
+		for i := 0; i < 5; i++ {
+			variant, ok := cur.Value.(*commonv1.AnyValue_ArrayValue)
+			require.True(t, ok, "expected ArrayValue at depth %d", i)
+			require.Len(t, variant.ArrayValue.Values, 1)
+			cur = &variant.ArrayValue.Values[0]
+		}
+		sv, ok := cur.Value.(*commonv1.AnyValue_StringValue)
+		require.True(t, ok)
+		assert.Equal(t, "hello", sv.StringValue)
+	})
+
+	t.Run("deep nesting returns error", func(t *testing.T) {
+		// Each nesting level adds 2 recursion depth increments
+		// (AnyValue -> ArrayValue -> AnyValue), so 10001 wraps = 20002
+		// depth increments, well past the 10000 limit.
+		b := buildNestedAnyValueBytes(10001)
+		var av commonv1.AnyValue
+		err := av.Unmarshal(b)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeded max recursion depth")
+	})
+}


### PR DESCRIPTION
## Summary
- Generated `Unmarshal` methods now track recursion depth to prevent stack overflow from deeply nested messages
- Each message emits a public `Unmarshal([]byte) error` wrapper calling a private `unmarshal([]byte, int) error` that checks `depth > 10000` (matching protobuf-go's limit)
- OTel protos have real cycles (`AnyValue -> ArrayValue -> AnyValue` and `AnyValue -> KeyValueList -> KeyValue -> AnyValue`) that a crafted input can exploit to cause unbounded recursion
- Cross-package recursive calls correctly use the public `Unmarshal` since the private method is unexported

## Test plan
- [x] New `TestUnmarshalDepthLimit` verifies both shallow nesting (5 levels) succeeds and deep nesting (10001 wraps) returns an error
- [x] All existing correctness tests pass (`make test`)
- [x] Fuzz tests pass (`make fuzz`)
- [x] Build succeeds (`make build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)