### PR TITLE
fix: improve conformance Docker cache correctness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Only conformance tests use Docker. Keep the build context minimal:
+# the testee binary needs go.mod, go.sum, gen/protohelpers/,
+# gen/protobuf_test_messages/, and conformance/{internal,testee}/.
+.git
+bench/
+test/
+compiler/
+cmd/
+proto/
+gen/otlp/
+gen/vtpb/
+gen/gogopb/
+*.prof
+*.test
+benchstat.txt

--- a/conformance/Dockerfile
+++ b/conformance/Dockerfile
@@ -31,7 +31,12 @@ FROM golang:1.26 AS testee-builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
-COPY . .
+# Copy only what the testee binary needs so the cache invalidates precisely
+# when dependencies change, not on unrelated file edits.
+COPY gen/protohelpers/ gen/protohelpers/
+COPY gen/protobuf_test_messages/ gen/protobuf_test_messages/
+COPY conformance/internal/ conformance/internal/
+COPY conformance/testee/ conformance/testee/
 RUN CGO_ENABLED=0 go build -o /testee ./conformance/testee/
 
 # --- Stage 3: Run conformance tests ---


### PR DESCRIPTION
Add .dockerignore and replace `COPY . .` with targeted COPY commands so the testee layer invalidates only when its actual dependencies change. Build context drops from ~68MB to ~117KB.