### PR TITLE
feat: add Equal methods, proto comments, and non-nil empty Marshal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.prof
 *.test
 benchstat.txt
+coverage.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ All commands are available via `make`:
 | `make fuzz` | Fuzz `Unmarshal` methods (30s) — feeds random bytes to verify errors, not panics |
 | `make generate` | Regenerate all code (ours + vtproto + gogoproto). Requires `protoc`, `protoc-gen-go`, `protoc-gen-go-vtproto`, `protoc-gen-gogofast` |
 | `make generate-ours` | Regenerate all wiresmith + conformance code. Requires `protoc`, `protoc-gen-go` |
+| `make coverage` | Run tests with coverage report |
 | `make bench` | Run comparative benchmarks (5 iterations) |
 | `make bench-compare` | Run per-library benchmarks and compare with `benchstat`. Accepts `COUNT=-count=N` |
 | `make conformance` | Run Google protobuf conformance tests in Docker |
@@ -62,3 +63,7 @@ docker run --rm --entrypoint conformance_test_runner wiresmith-conformance /usr/
 ```
 
 Compare the `unexpected failures` output against `conformance/failure_list.txt` and remove entries that no longer appear. The expected failure count in the runner output should equal the number of entries in the file.
+
+## Known issues
+
+- `go test ./...` panics in `bench/` with `proto: file "maps.proto" is already registered` due to conflicting proto registrations between `gen/bench/official`, `gen/bench/vtpb`, and `gen/bench/gogopb`. Use `go test ./test/ ./compiler/...` to run tests without the bench package, or `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn go test ./bench/` to run benchmarks.

--- a/MIMIR.md
+++ b/MIMIR.md
@@ -1,7 +1,12 @@
 # Mimir Compatibility: Remaining Changes
 
 Changes from the `mimir-compat` branch not yet ported to `main`.
-Inline unmarshal optimization (iNdEx/dAtA pattern) was implemented in #31.
+
+Already implemented:
+- Inline unmarshal optimization (iNdEx/dAtA pattern) — #31
+- `Marshal` returns non-nil slice for empty messages — #32
+- `Equal(that interface{}) bool` per-message equality — #32
+- Proto source comments preserved in generated code — #32
 
 ## Method Signature Changes (generally applicable)
 
@@ -11,11 +16,6 @@ Target:  `func (m *T) MarshalToSizedBuffer(dAtA []byte) (int, error)`
 - All internal callers (nested message marshal) must propagate the error.
 - `MessageType.EmitMarshal` and `EmitValueMarshal` in `compiler/types/message.go` already emit `(int, error)` return handling — the emitter itself needs updating in `emit_marshal.go`.
 
-### `Marshal` returns non-nil slice for empty messages
-Current: `if size == 0 { return nil, nil }`
-Target:  allocate `dAtA = make([]byte, size)` before the zero check, return `dAtA, nil`.
-Also use named returns: `func (m *T) Marshal() (dAtA []byte, err error)`.
-
 ### New `MarshalTo` method
 ```go
 func (m *T) MarshalTo(dAtA []byte) (int, error) {
@@ -23,18 +23,6 @@ func (m *T) MarshalTo(dAtA []byte) (int, error) {
     return m.MarshalToSizedBuffer(dAtA[:size])
 }
 ```
-
-## New Methods (generally applicable)
-
-### `Equal(that interface{}) bool`
-Per-message equality method. Handles:
-- Nil receiver / nil argument → equal
-- Type assertion (pointer and value)
-- Per-field comparison: scalars `!=`, `bytes.Equal`, recursive `.Equal()` for messages
-- Map comparison: length + per-key value check
-- Repeated: length + per-element
-- Optional: nil checks + pointer dereference
-- Oneof: type switch + variant comparison
 
 ## Gogo-Specific Features (require GogoCompat flag)
 

--- a/MIMIR.md
+++ b/MIMIR.md
@@ -1,0 +1,74 @@
+# Mimir Compatibility: Remaining Changes
+
+Changes from the `mimir-compat` branch not yet ported to `main`.
+Inline unmarshal optimization (iNdEx/dAtA pattern) was implemented in #31.
+
+## Method Signature Changes (generally applicable)
+
+### `MarshalToSizedBuffer` returns `(int, error)` instead of `int`
+Current: `func (m *T) MarshalToSizedBuffer(dAtA []byte) int`
+Target:  `func (m *T) MarshalToSizedBuffer(dAtA []byte) (int, error)`
+- All internal callers (nested message marshal) must propagate the error.
+- `MessageType.EmitMarshal` and `EmitValueMarshal` in `compiler/types/message.go` already emit `(int, error)` return handling — the emitter itself needs updating in `emit_marshal.go`.
+
+### `Marshal` returns non-nil slice for empty messages
+Current: `if size == 0 { return nil, nil }`
+Target:  allocate `dAtA = make([]byte, size)` before the zero check, return `dAtA, nil`.
+Also use named returns: `func (m *T) Marshal() (dAtA []byte, err error)`.
+
+### New `MarshalTo` method
+```go
+func (m *T) MarshalTo(dAtA []byte) (int, error) {
+    size := m.Size()
+    return m.MarshalToSizedBuffer(dAtA[:size])
+}
+```
+
+## New Methods (generally applicable)
+
+### `Equal(that interface{}) bool`
+Per-message equality method. Handles:
+- Nil receiver / nil argument → equal
+- Type assertion (pointer and value)
+- Per-field comparison: scalars `!=`, `bytes.Equal`, recursive `.Equal()` for messages
+- Map comparison: length + per-key value check
+- Repeated: length + per-element
+- Optional: nil checks + pointer dereference
+- Oneof: type switch + variant comparison
+
+## Gogo-Specific Features (require GogoCompat flag)
+
+These are NOT generally applicable — they only matter for gogo/protobuf drop-in replacement.
+
+### Struct tags
+- `protobuf:"varint,1,opt,name=foo,json=fooBar,proto3"` tags on struct fields
+- `protobuf_oneof:"field_name"` tags on oneof interface fields
+
+### Gogo method set
+- `Reset()`, `ProtoMessage()`, `String()`, `GoString()`
+- `XXX_*` methods (deprecated but required for gogo compat)
+- Getter methods (`Get*()` for each field)
+- Registration: `proto.RegisterType()` / `proto.RegisterEnum()` in `init()`
+
+### Pointer semantics
+- `(gogoproto.nullable)` support — message fields as `*T` instead of `T`
+- `(gogoproto.customtype)` — replace Go type entirely
+- `(gogoproto.casttype)` — cast to different type name
+
+### Well-known type helpers
+- `google.protobuf.Duration` → `time.Duration` with `StdDurationMarshal/Unmarshal`
+- `google.protobuf.Timestamp` → `time.Time` with `StdTimeMarshal/Unmarshal`
+
+### gRPC service stubs
+- Client/server interfaces, handlers, service descriptors
+
+### Enum prefixing
+- `(gogoproto.goproto_enum_prefix)` — prefix enum values with parent message name
+
+### Multi-path proto resolution
+- `ProtoPaths []string` and `ProtoFiles []string` on Generator
+- `multiPathResolver` for cross-directory proto imports
+
+### Output conventions
+- `.pb.go` suffix instead of `.go`
+- `go_package` option for output directory

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ space := $(empty) $(empty)
 comma := ,
 gogo_mflags = $(subst $(space),,$(foreach p,$(ALL_PROTOS),M$(p)=$(MODULE)/$(1)/$(call pkgsuffix,$(p))$(comma)))
 
-.PHONY: help build test fuzz generate bench bench-compare clean conformance
+.PHONY: help build test coverage fuzz generate bench bench-compare clean conformance
 
 help: ## Print this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
@@ -39,6 +39,12 @@ build: ## Build all packages
 
 test: ## Run correctness tests
 	go test ./test/ -v
+
+coverage: ## Run tests with coverage report
+	go test ./test/ ./compiler/... -coverprofile=coverage.out
+	go tool cover -func=coverage.out
+	@echo ""
+	@echo "HTML report: go tool cover -html=coverage.out"
 
 fuzz: ## Fuzz all targets (30s each)
 	@for target in FuzzUnmarshal FuzzRoundTrip FuzzMarshalSize FuzzCrossLibrary FuzzStructuredTrace FuzzStructuredMetrics FuzzStructuredLogs; do \

--- a/compiler/generator/emit_enum.go
+++ b/compiler/generator/emit_enum.go
@@ -9,10 +9,17 @@ import (
 func (fg *FileGenerator) emitEnum(ed protoreflect.EnumDescriptor) {
 	typeName := goEnumTypeName(ed)
 
+	if c := leadingComment(ed); c != "" {
+		fg.body.WriteString(c)
+	}
+
 	fmt.Fprintf(fg.body, "type %s int32\n\n", typeName)
 	fmt.Fprintf(fg.body, "const (\n")
 	for i := 0; i < ed.Values().Len(); i++ {
 		v := ed.Values().Get(i)
+		if c := leadingComment(v); c != "" {
+			fg.body.WriteString(indentComment(c))
+		}
 		fmt.Fprintf(fg.body, "\t%s %s = %d\n", string(v.Name()), typeName, v.Number())
 	}
 	fmt.Fprintf(fg.body, ")\n\n")

--- a/compiler/generator/emit_equal.go
+++ b/compiler/generator/emit_equal.go
@@ -1,0 +1,155 @@
+package generator
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func (fg *FileGenerator) emitAllEqualMethods(fd protoreflect.FileDescriptor) {
+	for i := 0; i < fd.Messages().Len(); i++ {
+		fg.emitEqualMethods(fd.Messages().Get(i))
+	}
+}
+
+func (fg *FileGenerator) emitEqualMethods(md protoreflect.MessageDescriptor) {
+	for i := 0; i < md.Messages().Len(); i++ {
+		nested := md.Messages().Get(i)
+		if nested.IsMapEntry() {
+			continue
+		}
+		fg.emitEqualMethods(nested)
+	}
+	fg.emitEqual(md)
+}
+
+func (fg *FileGenerator) emitEqual(md protoreflect.MessageDescriptor) {
+	name := goMessageTypeName(md)
+
+	if needsBytesImportForEqual(md) {
+		fg.imports.addImport("bytes", "")
+	}
+
+	fmt.Fprintf(fg.body, "func (this *%s) Equal(that interface{}) bool {\n", name)
+	fmt.Fprintf(fg.body, "\tif that == nil {\n\t\treturn this == nil\n\t}\n\n")
+
+	fmt.Fprintf(fg.body, "\tthat1, ok := that.(*%s)\n", name)
+	fmt.Fprintf(fg.body, "\tif !ok {\n")
+	fmt.Fprintf(fg.body, "\t\tthat2, ok := that.(%s)\n", name)
+	fmt.Fprintf(fg.body, "\t\tif ok {\n\t\t\tthat1 = &that2\n\t\t} else {\n\t\t\treturn false\n\t\t}\n")
+	fmt.Fprintf(fg.body, "\t}\n")
+	fmt.Fprintf(fg.body, "\tif that1 == nil {\n\t\treturn this == nil\n\t} else if this == nil {\n\t\treturn false\n\t}\n")
+
+	seenOneofs := map[string]bool{}
+	for i := 0; i < md.Fields().Len(); i++ {
+		fd := md.Fields().Get(i)
+
+		if isRealOneof(fd) {
+			oo := fd.ContainingOneof()
+			ooName := string(oo.Name())
+			if !seenOneofs[ooName] {
+				seenOneofs[ooName] = true
+				goName := snakeToPascal(ooName)
+				fmt.Fprintf(fg.body, "\tif this.%s != that1.%s {\n", goName, goName)
+				fmt.Fprintf(fg.body, "\t\treturn false\n\t}\n")
+			}
+			continue
+		}
+
+		goName := snakeToPascal(string(fd.Name()))
+		fg.emitFieldEqual(fd, goName)
+	}
+
+	fmt.Fprintf(fg.body, "\treturn true\n")
+	fmt.Fprintf(fg.body, "}\n\n")
+}
+
+func (fg *FileGenerator) emitFieldEqual(fd protoreflect.FieldDescriptor, goName string) {
+	if fd.IsList() {
+		fg.emitRepeatedFieldEqual(fd, goName)
+		return
+	}
+	if fd.HasOptionalKeyword() {
+		// []byte is already nullable — use bytes.Equal, not pointer deref.
+		if fd.Kind() == protoreflect.BytesKind {
+			fmt.Fprintf(fg.body, "\tif !bytes.Equal(this.%s, that1.%s) {\n\t\treturn false\n\t}\n", goName, goName)
+			return
+		}
+		fg.emitOptionalFieldEqual(fd, goName)
+		return
+	}
+	if fd.IsMap() {
+		fg.emitMapFieldEqual(fd, goName)
+		return
+	}
+
+	switch fd.Kind() {
+	case protoreflect.BytesKind:
+		fmt.Fprintf(fg.body, "\tif !bytes.Equal(this.%s, that1.%s) {\n\t\treturn false\n\t}\n", goName, goName)
+	case protoreflect.MessageKind:
+		fmt.Fprintf(fg.body, "\tif !this.%s.Equal(that1.%s) {\n\t\treturn false\n\t}\n", goName, goName)
+	default:
+		fmt.Fprintf(fg.body, "\tif this.%s != that1.%s {\n\t\treturn false\n\t}\n", goName, goName)
+	}
+}
+
+func (fg *FileGenerator) emitOptionalFieldEqual(_ protoreflect.FieldDescriptor, goName string) {
+	fmt.Fprintf(fg.body, "\tif this.%s != that1.%s {\n", goName, goName)
+	fmt.Fprintf(fg.body, "\t\tif this.%s == nil || that1.%s == nil {\n\t\t\treturn false\n\t\t}\n", goName, goName)
+	fmt.Fprintf(fg.body, "\t\tif *this.%s != *that1.%s {\n\t\t\treturn false\n\t\t}\n", goName, goName)
+	fmt.Fprintf(fg.body, "\t}\n")
+}
+
+func (fg *FileGenerator) emitMapFieldEqual(fd protoreflect.FieldDescriptor, goName string) {
+	fmt.Fprintf(fg.body, "\tif len(this.%s) != len(that1.%s) {\n\t\treturn false\n\t}\n", goName, goName)
+	fmt.Fprintf(fg.body, "\tfor k, v := range this.%s {\n", goName)
+	fmt.Fprintf(fg.body, "\t\tv2, ok := that1.%s[k]\n", goName)
+	fmt.Fprintf(fg.body, "\t\tif !ok {\n\t\t\treturn false\n\t\t}\n")
+
+	valFd := fd.Message().Fields().ByNumber(2)
+	switch valFd.Kind() {
+	case protoreflect.MessageKind:
+		fmt.Fprintf(fg.body, "\t\tif !v.Equal(v2) {\n\t\t\treturn false\n\t\t}\n")
+	case protoreflect.BytesKind:
+		fmt.Fprintf(fg.body, "\t\tif !bytes.Equal(v, v2) {\n\t\t\treturn false\n\t\t}\n")
+	default:
+		fmt.Fprintf(fg.body, "\t\tif v != v2 {\n\t\t\treturn false\n\t\t}\n")
+	}
+	fmt.Fprintf(fg.body, "\t}\n")
+}
+
+func (fg *FileGenerator) emitRepeatedFieldEqual(fd protoreflect.FieldDescriptor, goName string) {
+	fmt.Fprintf(fg.body, "\tif len(this.%s) != len(that1.%s) {\n\t\treturn false\n\t}\n", goName, goName)
+	fmt.Fprintf(fg.body, "\tfor i := range this.%s {\n", goName)
+
+	switch fd.Kind() {
+	case protoreflect.BytesKind:
+		fmt.Fprintf(fg.body, "\t\tif !bytes.Equal(this.%s[i], that1.%s[i]) {\n\t\t\treturn false\n\t\t}\n", goName, goName)
+	case protoreflect.MessageKind:
+		fmt.Fprintf(fg.body, "\t\tif !this.%s[i].Equal(that1.%s[i]) {\n\t\t\treturn false\n\t\t}\n", goName, goName)
+	default:
+		fmt.Fprintf(fg.body, "\t\tif this.%s[i] != that1.%s[i] {\n\t\t\treturn false\n\t\t}\n", goName, goName)
+	}
+
+	fmt.Fprintf(fg.body, "\t}\n")
+}
+
+func needsBytesImportForEqual(md protoreflect.MessageDescriptor) bool {
+	for i := 0; i < md.Fields().Len(); i++ {
+		fd := md.Fields().Get(i)
+		// Skip oneof fields — we compare the interface directly.
+		if isRealOneof(fd) {
+			continue
+		}
+		if fd.Kind() == protoreflect.BytesKind {
+			return true
+		}
+		if fd.IsMap() {
+			valFd := fd.Message().Fields().ByNumber(2)
+			if valFd.Kind() == protoreflect.BytesKind {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/compiler/generator/emit_equal.go
+++ b/compiler/generator/emit_equal.go
@@ -49,9 +49,7 @@ func (fg *FileGenerator) emitEqual(md protoreflect.MessageDescriptor) {
 			ooName := string(oo.Name())
 			if !seenOneofs[ooName] {
 				seenOneofs[ooName] = true
-				goName := snakeToPascal(ooName)
-				fmt.Fprintf(fg.body, "\tif this.%s != that1.%s {\n", goName, goName)
-				fmt.Fprintf(fg.body, "\t\treturn false\n\t}\n")
+				fg.emitOneofEqual(md, oo)
 			}
 			continue
 		}
@@ -64,14 +62,47 @@ func (fg *FileGenerator) emitEqual(md protoreflect.MessageDescriptor) {
 	fmt.Fprintf(fg.body, "}\n\n")
 }
 
+func (fg *FileGenerator) emitOneofEqual(md protoreflect.MessageDescriptor, oo protoreflect.OneofDescriptor) {
+	goName := snakeToPascal(string(oo.Name()))
+
+	fmt.Fprintf(fg.body, "\tif (this.%s == nil) != (that1.%s == nil) {\n", goName, goName)
+	fmt.Fprintf(fg.body, "\t\treturn false\n\t}\n")
+	fmt.Fprintf(fg.body, "\tif this.%s != nil {\n", goName)
+	fmt.Fprintf(fg.body, "\t\tswitch v := this.%s.(type) {\n", goName)
+
+	for i := 0; i < oo.Fields().Len(); i++ {
+		fd := oo.Fields().Get(i)
+		variantType := oneofVariantName(md, fd)
+		fieldName := snakeToPascal(string(fd.Name()))
+
+		fmt.Fprintf(fg.body, "\t\tcase *%s:\n", variantType)
+		fmt.Fprintf(fg.body, "\t\t\tv2, ok := that1.%s.(*%s)\n", goName, variantType)
+		fmt.Fprintf(fg.body, "\t\t\tif !ok {\n\t\t\t\treturn false\n\t\t\t}\n")
+
+		switch fd.Kind() {
+		case protoreflect.BytesKind:
+			fmt.Fprintf(fg.body, "\t\t\tif !bytes.Equal(v.%s, v2.%s) {\n\t\t\t\treturn false\n\t\t\t}\n", fieldName, fieldName)
+		case protoreflect.MessageKind:
+			fmt.Fprintf(fg.body, "\t\t\tif !v.%s.Equal(v2.%s) {\n\t\t\t\treturn false\n\t\t\t}\n", fieldName, fieldName)
+		default:
+			fmt.Fprintf(fg.body, "\t\t\tif v.%s != v2.%s {\n\t\t\t\treturn false\n\t\t\t}\n", fieldName, fieldName)
+		}
+	}
+
+	fmt.Fprintf(fg.body, "\t\tdefault:\n\t\t\treturn false\n")
+	fmt.Fprintf(fg.body, "\t\t}\n")
+	fmt.Fprintf(fg.body, "\t}\n")
+}
+
 func (fg *FileGenerator) emitFieldEqual(fd protoreflect.FieldDescriptor, goName string) {
 	if fd.IsList() {
 		fg.emitRepeatedFieldEqual(fd, goName)
 		return
 	}
 	if fd.HasOptionalKeyword() {
-		// []byte is already nullable — use bytes.Equal, not pointer deref.
+		// optional bytes: distinguish nil (unset) from []byte{} (set to empty).
 		if fd.Kind() == protoreflect.BytesKind {
+			fmt.Fprintf(fg.body, "\tif (this.%s == nil) != (that1.%s == nil) {\n\t\treturn false\n\t}\n", goName, goName)
 			fmt.Fprintf(fg.body, "\tif !bytes.Equal(this.%s, that1.%s) {\n\t\treturn false\n\t}\n", goName, goName)
 			return
 		}
@@ -137,10 +168,6 @@ func (fg *FileGenerator) emitRepeatedFieldEqual(fd protoreflect.FieldDescriptor,
 func needsBytesImportForEqual(md protoreflect.MessageDescriptor) bool {
 	for i := 0; i < md.Fields().Len(); i++ {
 		fd := md.Fields().Get(i)
-		// Skip oneof fields — we compare the interface directly.
-		if isRealOneof(fd) {
-			continue
-		}
 		if fd.Kind() == protoreflect.BytesKind {
 			return true
 		}

--- a/compiler/generator/emit_marshal.go
+++ b/compiler/generator/emit_marshal.go
@@ -16,8 +16,8 @@ func (fg *FileGenerator) emitMarshal(md protoreflect.MessageDescriptor) {
 	// Marshal allocates and returns the encoded bytes.
 	fmt.Fprintf(fg.body, "func (m *%s) Marshal() (dAtA []byte, err error) {\n", name)
 	fmt.Fprintf(fg.body, "\tsize := m.Size()\n")
-	fmt.Fprintf(fg.body, "\tif size == 0 {\n\t\treturn nil, nil\n\t}\n")
 	fmt.Fprintf(fg.body, "\tdAtA = make([]byte, size)\n")
+	fmt.Fprintf(fg.body, "\tif size == 0 {\n\t\treturn dAtA, nil\n\t}\n")
 	fmt.Fprintf(fg.body, "\tn, err := m.MarshalToSizedBuffer(dAtA[:size])\n")
 	fmt.Fprintf(fg.body, "\tif err != nil {\n\t\treturn nil, err\n\t}\n")
 	fmt.Fprintf(fg.body, "\treturn dAtA[:n], nil\n")

--- a/compiler/generator/emit_struct.go
+++ b/compiler/generator/emit_struct.go
@@ -8,6 +8,11 @@ import (
 
 func (fg *FileGenerator) emitStruct(md protoreflect.MessageDescriptor) {
 	name := goMessageTypeName(md)
+
+	if c := leadingComment(md); c != "" {
+		fg.body.WriteString(c)
+	}
+
 	fmt.Fprintf(fg.body, "type %s struct {\n", name)
 
 	seenOneofs := map[string]bool{}
@@ -15,6 +20,9 @@ func (fg *FileGenerator) emitStruct(md protoreflect.MessageDescriptor) {
 		fd := md.Fields().Get(i)
 
 		if fd.IsMap() {
+			if c := leadingComment(fd); c != "" {
+				fg.body.WriteString(indentComment(c))
+			}
 			goName := snakeToPascal(string(fd.Name()))
 			goType := fg.imports.goType(fd)
 			fmt.Fprintf(fg.body, "\t%s %s\n", goName, goType)
@@ -25,6 +33,9 @@ func (fg *FileGenerator) emitStruct(md protoreflect.MessageDescriptor) {
 			ooName := string(oo.Name())
 			if !seenOneofs[ooName] {
 				seenOneofs[ooName] = true
+				if c := leadingComment(oo); c != "" {
+					fg.body.WriteString(indentComment(c))
+				}
 				goName := snakeToPascal(ooName)
 				ifaceName := oneofInterfaceName(md, oo)
 				fmt.Fprintf(fg.body, "\t%s %s\n", goName, ifaceName)
@@ -32,6 +43,9 @@ func (fg *FileGenerator) emitStruct(md protoreflect.MessageDescriptor) {
 			continue
 		}
 
+		if c := leadingComment(fd); c != "" {
+			fg.body.WriteString(indentComment(c))
+		}
 		goName := snakeToPascal(string(fd.Name()))
 		goType := fg.imports.goType(fd)
 		fmt.Fprintf(fg.body, "\t%s %s\n", goName, goType)

--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -67,7 +67,8 @@ func (g *Generator) Generate(ctx context.Context) error {
 
 	resolver := &memResolver{files: mapping}
 	compiler := protocompile.Compiler{
-		Resolver: resolver,
+		Resolver:       resolver,
+		SourceInfoMode: protocompile.SourceInfoStandard,
 		Reporter: reporter.NewReporter(
 			func(err reporter.ErrorWithPos) error { return err },
 			nil,
@@ -101,6 +102,7 @@ func (g *Generator) generateFile(fd protoreflect.FileDescriptor) error {
 	fg.emitAllSizeMethods(fd)
 	fg.emitAllMarshalMethods(fd)
 	fg.emitAllUnmarshalMethods(fd)
+	fg.emitAllEqualMethods(fd)
 
 	var out bytes.Buffer
 	fg.emitHeader(&out)

--- a/compiler/generator/generator_test.go
+++ b/compiler/generator/generator_test.go
@@ -30,9 +30,23 @@ func repoRoot(t *testing.T) string {
 
 func TestGeneratorDeterminism(t *testing.T) {
 	root := repoRoot(t)
-	protoDir := filepath.Join(root, "proto", "otlp")
 
-	const iterations = 5
+	for _, tc := range []struct {
+		name     string
+		protoDir string
+	}{
+		{"otlp", filepath.Join(root, "proto", "otlp")},
+		{"kitchen_sink", filepath.Join(root, "proto", "test")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			checkDeterminism(t, tc.protoDir, 5)
+		})
+	}
+}
+
+func checkDeterminism(t *testing.T, protoDir string, iterations int) {
+	t.Helper()
+
 	for i := 0; i < iterations; i++ {
 		dirA := t.TempDir()
 		dirB := t.TempDir()

--- a/compiler/generator/names.go
+++ b/compiler/generator/names.go
@@ -72,3 +72,36 @@ func goEnumTypeName(ed protoreflect.EnumDescriptor) string {
 	}
 	return name
 }
+
+// leadingComment extracts the leading comment from a proto descriptor's
+// source location and formats it as a Go comment block.
+func leadingComment(d protoreflect.Descriptor) string {
+	loc := d.ParentFile().SourceLocations().ByDescriptor(d)
+	comment := strings.TrimSpace(loc.LeadingComments)
+	if comment == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(comment, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			b.WriteString("//\n")
+		} else {
+			b.WriteString("// ")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// indentComment adds a tab prefix to each line of a Go comment block.
+func indentComment(comment string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(strings.TrimSuffix(comment, "\n"), "\n") {
+		b.WriteByte('\t')
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/gen/bench/maps/v1/maps.go
+++ b/gen/bench/maps/v1/maps.go
@@ -4,6 +4,7 @@
 package mapsv1
 
 import (
+	"bytes"
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
 	"wiresmith/gen/protohelpers"
@@ -61,10 +62,10 @@ func (m *Inner) Size() int {
 
 func (m *MapBench) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -131,10 +132,10 @@ func (m *MapBench) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Inner) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -550,4 +551,93 @@ func (m *Inner) unmarshal(b []byte, depth int) error {
 		}
 	}
 	return nil
+}
+
+func (this *MapBench) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*MapBench)
+	if !ok {
+		that2, ok := that.(MapBench)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.StringMap) != len(that1.StringMap) {
+		return false
+	}
+	for k, v := range this.StringMap {
+		v2, ok := that1.StringMap[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.IntMap) != len(that1.IntMap) {
+		return false
+	}
+	for k, v := range this.IntMap {
+		v2, ok := that1.IntMap[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MessageMap) != len(that1.MessageMap) {
+		return false
+	}
+	for k, v := range this.MessageMap {
+		v2, ok := that1.MessageMap[k]
+		if !ok {
+			return false
+		}
+		if !v.Equal(v2) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Inner) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Inner)
+	if !ok {
+		that2, ok := that.(Inner)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Name != that1.Name {
+		return false
+	}
+	if this.Value != that1.Value {
+		return false
+	}
+	if !bytes.Equal(this.Data, that1.Data) {
+		return false
+	}
+	return true
 }

--- a/gen/otlp/common/v1/common.go
+++ b/gen/otlp/common/v1/common.go
@@ -4,6 +4,7 @@
 package commonv1
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -1251,8 +1252,78 @@ func (this *AnyValue) Equal(that interface{}) bool {
 	} else if this == nil {
 		return false
 	}
-	if this.Value != that1.Value {
+	if (this.Value == nil) != (that1.Value == nil) {
 		return false
+	}
+	if this.Value != nil {
+		switch v := this.Value.(type) {
+		case *AnyValue_StringValue:
+			v2, ok := that1.Value.(*AnyValue_StringValue)
+			if !ok {
+				return false
+			}
+			if v.StringValue != v2.StringValue {
+				return false
+			}
+		case *AnyValue_BoolValue:
+			v2, ok := that1.Value.(*AnyValue_BoolValue)
+			if !ok {
+				return false
+			}
+			if v.BoolValue != v2.BoolValue {
+				return false
+			}
+		case *AnyValue_IntValue:
+			v2, ok := that1.Value.(*AnyValue_IntValue)
+			if !ok {
+				return false
+			}
+			if v.IntValue != v2.IntValue {
+				return false
+			}
+		case *AnyValue_DoubleValue:
+			v2, ok := that1.Value.(*AnyValue_DoubleValue)
+			if !ok {
+				return false
+			}
+			if v.DoubleValue != v2.DoubleValue {
+				return false
+			}
+		case *AnyValue_ArrayValue:
+			v2, ok := that1.Value.(*AnyValue_ArrayValue)
+			if !ok {
+				return false
+			}
+			if !v.ArrayValue.Equal(v2.ArrayValue) {
+				return false
+			}
+		case *AnyValue_KvlistValue:
+			v2, ok := that1.Value.(*AnyValue_KvlistValue)
+			if !ok {
+				return false
+			}
+			if !v.KvlistValue.Equal(v2.KvlistValue) {
+				return false
+			}
+		case *AnyValue_BytesValue:
+			v2, ok := that1.Value.(*AnyValue_BytesValue)
+			if !ok {
+				return false
+			}
+			if !bytes.Equal(v.BytesValue, v2.BytesValue) {
+				return false
+			}
+		case *AnyValue_StringValueStrindex:
+			v2, ok := that1.Value.(*AnyValue_StringValueStrindex)
+			if !ok {
+				return false
+			}
+			if v.StringValueStrindex != v2.StringValueStrindex {
+				return false
+			}
+		default:
+			return false
+		}
 	}
 	return true
 }

--- a/gen/otlp/common/v1/common.go
+++ b/gen/otlp/common/v1/common.go
@@ -63,35 +63,107 @@ type AnyValue_StringValueStrindex struct {
 
 func (*AnyValue_StringValueStrindex) isAnyValue_Value() {}
 
+// Represents any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
 type AnyValue struct {
+	// The value is one of the listed fields. It is valid for all values to be unspecified
+	// in which case this AnyValue is considered to be "empty".
 	Value AnyValue_Value
 }
 
+// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+// since oneof in AnyValue does not allow repeated fields.
 type ArrayValue struct {
+	// Array of values. The array may be empty (contain 0 elements).
 	Values []AnyValue
 }
 
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
 type KeyValueList struct {
+	// A collection of key/value pairs of key-value pairs. The list may be empty (may
+	// contain 0 elements).
+	//
+	// The keys MUST be unique (it is not allowed to have more than one
+	// value with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
 	Values []KeyValue
 }
 
+// Represents a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
 type KeyValue struct {
-	Key         string
-	Value       AnyValue
+	// The key name of the pair.
+	// key_strindex MUST NOT be set if key is used.
+	Key string
+	// The value of the pair.
+	Value AnyValue
+	// Reference to the string key in ProfilesDictionary.string_table.
+	// key MUST NOT be set if key_strindex is used.
+	//
+	// Note: This is currently used exclusively in the Profiling signal.
+	// Implementers of OTLP receivers for signals other than Profiling should
+	// treat the presence of this key as a non-fatal issue.
+	// Log an error or warning indicating an unexpected field intended for the
+	// Profiling signal and process the data as if this value were absent or
+	// empty, ignoring its semantic content for the non-Profiling signal.
+	//
+	// Status: [Alpha]
 	KeyStrindex int32
 }
 
+// InstrumentationScope is a message representing the instrumentation scope information
+// such as the fully qualified name and version.
 type InstrumentationScope struct {
-	Name                   string
-	Version                string
-	Attributes             []KeyValue
+	// A name denoting the Instrumentation scope.
+	// An empty instrumentation scope name means the name is unknown.
+	Name string
+	// Defines the version of the instrumentation scope.
+	// An empty instrumentation scope version means the version is unknown.
+	Version string
+	// Additional attributes that describe the scope. [Optional].
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Attributes []KeyValue
+	// The number of attributes that were discarded. Attributes
+	// can be discarded because their keys are too long or because there are too many
+	// attributes. If this value is 0, then no attributes were dropped.
 	DroppedAttributesCount uint32
 }
 
+// A reference to an Entity.
+// Entity represents an object of interest associated with produced telemetry: e.g spans, metrics, profiles, or logs.
+//
+// Status: [Development]
 type EntityRef struct {
-	SchemaUrl       string
-	Type            string
-	IdKeys          []string
+	// The Schema URL, if known. This is the identifier of the Schema that the entity data
+	// is recorded in. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	//
+	// This schema_url applies to the data in this message and to the Resource attributes
+	// referenced by id_keys and description_keys.
+	// TODO: discuss if we are happy with this somewhat complicated definition of what
+	// the schema_url applies to.
+	//
+	// This field obsoletes the schema_url field in ResourceMetrics/ResourceSpans/ResourceLogs.
+	SchemaUrl string
+	// Defines the type of the entity. MUST not change during the lifetime of the entity.
+	// For example: "service" or "host". This field is required and MUST not be empty
+	// for valid entities.
+	Type string
+	// Attribute Keys that identify the entity.
+	// MUST not change during the lifetime of the entity. The Id must contain at least one attribute.
+	// These keys MUST exist in the containing {message}.attributes.
+	IdKeys []string
+	// Descriptive (non-identifying) attribute keys of the entity.
+	// MAY change over the lifetime of the entity. MAY be empty.
+	// These attribute keys are not part of entity's identity.
+	// These keys MUST exist in the containing {message}.attributes.
 	DescriptionKeys []string
 }
 
@@ -196,10 +268,10 @@ func (m *EntityRef) Size() int {
 
 func (m *AnyValue) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -273,10 +345,10 @@ func (m *AnyValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ArrayValue) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -306,10 +378,10 @@ func (m *ArrayValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *KeyValueList) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -339,10 +411,10 @@ func (m *KeyValueList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *KeyValue) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -386,10 +458,10 @@ func (m *KeyValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *InstrumentationScope) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -438,10 +510,10 @@ func (m *InstrumentationScope) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *EntityRef) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1158,4 +1230,203 @@ func (m *EntityRef) unmarshal(b []byte, depth int) error {
 		}
 	}
 	return nil
+}
+
+func (this *AnyValue) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*AnyValue)
+	if !ok {
+		that2, ok := that.(AnyValue)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Value != that1.Value {
+		return false
+	}
+	return true
+}
+
+func (this *ArrayValue) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ArrayValue)
+	if !ok {
+		that2, ok := that.(ArrayValue)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Values) != len(that1.Values) {
+		return false
+	}
+	for i := range this.Values {
+		if !this.Values[i].Equal(that1.Values[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *KeyValueList) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*KeyValueList)
+	if !ok {
+		that2, ok := that.(KeyValueList)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Values) != len(that1.Values) {
+		return false
+	}
+	for i := range this.Values {
+		if !this.Values[i].Equal(that1.Values[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *KeyValue) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*KeyValue)
+	if !ok {
+		that2, ok := that.(KeyValue)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Key != that1.Key {
+		return false
+	}
+	if !this.Value.Equal(that1.Value) {
+		return false
+	}
+	if this.KeyStrindex != that1.KeyStrindex {
+		return false
+	}
+	return true
+}
+
+func (this *InstrumentationScope) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*InstrumentationScope)
+	if !ok {
+		that2, ok := that.(InstrumentationScope)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Name != that1.Name {
+		return false
+	}
+	if this.Version != that1.Version {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.DroppedAttributesCount != that1.DroppedAttributesCount {
+		return false
+	}
+	return true
+}
+
+func (this *EntityRef) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*EntityRef)
+	if !ok {
+		that2, ok := that.(EntityRef)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.SchemaUrl != that1.SchemaUrl {
+		return false
+	}
+	if this.Type != that1.Type {
+		return false
+	}
+	if len(this.IdKeys) != len(that1.IdKeys) {
+		return false
+	}
+	for i := range this.IdKeys {
+		if this.IdKeys[i] != that1.IdKeys[i] {
+			return false
+		}
+	}
+	if len(this.DescriptionKeys) != len(that1.DescriptionKeys) {
+		return false
+	}
+	for i := range this.DescriptionKeys {
+		if this.DescriptionKeys[i] != that1.DescriptionKeys[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/gen/otlp/logs/v1/logs.go
+++ b/gen/otlp/logs/v1/logs.go
@@ -4,6 +4,7 @@
 package logsv1
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -12,6 +13,7 @@ import (
 	"wiresmith/gen/protohelpers"
 )
 
+// Possible values for LogRecord.SeverityNumber.
 type SeverityNumber int32
 
 const (
@@ -42,41 +44,156 @@ const (
 	SEVERITY_NUMBER_FATAL4      SeverityNumber = 24
 )
 
+// LogRecordFlags represents constants used to interpret the
+// LogRecord.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
+//
+// (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
 type LogRecordFlags int32
 
 const (
-	LOG_RECORD_FLAGS_DO_NOT_USE       LogRecordFlags = 0
+	// The zero value for the enum. Should not be used for comparisons.
+	// Instead use bitwise "and" with the appropriate mask as shown above.
+	LOG_RECORD_FLAGS_DO_NOT_USE LogRecordFlags = 0
+	// Bits 0-7 are used for trace flags.
 	LOG_RECORD_FLAGS_TRACE_FLAGS_MASK LogRecordFlags = 255
 )
 
+// LogsData represents the logs data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP logs data but do not
+// implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
 type LogsData struct {
+	// An array of ResourceLogs.
+	// For data coming from a single resource this array will typically contain
+	// one element. Intermediary nodes that receive data from multiple origins
+	// typically batch the data before forwarding further and in that case this
+	// array will contain multiple elements.
 	ResourceLogs []ResourceLogs
 }
 
+// A collection of ScopeLogs from a Resource.
 type ResourceLogs struct {
-	Resource  resourcev1.Resource
+	// The resource for the logs in this message.
+	// If this field is not set then resource info is unknown.
+	Resource resourcev1.Resource
+	// A list of ScopeLogs that originate from a resource.
 	ScopeLogs []ScopeLogs
+	// The Schema URL, if known. This is the identifier of the Schema that the resource data
+	// is recorded in. Notably, the last part of the URL path is the version number of the
+	// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	// This schema_url applies to the data in the "resource" field. It does not apply
+	// to the data in the "scope_logs" field which have their own schema_url field.
 	SchemaUrl string
 }
 
+// A collection of Logs produced by a Scope.
 type ScopeLogs struct {
-	Scope      commonv1.InstrumentationScope
+	// The instrumentation scope information for the logs in this message.
+	// Semantically when InstrumentationScope isn't set, it is equivalent with
+	// an empty instrumentation scope name (unknown).
+	Scope commonv1.InstrumentationScope
+	// A list of log records.
 	LogRecords []LogRecord
-	SchemaUrl  string
+	// The Schema URL, if known. This is the identifier of the Schema that the log data
+	// is recorded in. Notably, the last part of the URL path is the version number of the
+	// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	// This schema_url applies to the data in the "scope" field and all logs in the
+	// "log_records" field.
+	SchemaUrl string
 }
 
+// A log record according to OpenTelemetry Log Data Model:
+// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
 type LogRecord struct {
-	TimeUnixNano           uint64
-	ObservedTimeUnixNano   uint64
-	SeverityNumber         SeverityNumber
-	SeverityText           string
-	Body                   commonv1.AnyValue
+	// time_unix_nano is the time when the event occurred.
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+	// Value of 0 indicates unknown or missing timestamp.
+	TimeUnixNano uint64
+	// Time when the event was observed by the collection system.
+	// For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
+	// this timestamp is typically set at the generation time and is equal to Timestamp.
+	// For events originating externally and collected by OpenTelemetry (e.g. using
+	// Collector) this is the time when OpenTelemetry's code observed the event measured
+	// by the clock of the OpenTelemetry code. This field MUST be set once the event is
+	// observed by OpenTelemetry.
+	//
+	// For converting OpenTelemetry log data to formats that support only one timestamp or
+	// when receiving OpenTelemetry log data by recipients that support only one timestamp
+	// internally the following logic is recommended:
+	// - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano.
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+	// Value of 0 indicates unknown or missing timestamp.
+	ObservedTimeUnixNano uint64
+	// Numerical value of the severity, normalized to values described in Log Data Model.
+	// [Optional].
+	SeverityNumber SeverityNumber
+	// The severity text (also known as log level). The original string representation as
+	// it is known at the source. [Optional].
+	SeverityText string
+	// A value containing the body of the log record. Can be for example a human-readable
+	// string message (including multi-line) describing the event in a free form or it can
+	// be a structured data composed of arrays and maps of other values. [Optional].
+	Body commonv1.AnyValue
+	// Additional attributes that describe the specific event occurrence. [Optional].
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
 	Attributes             []commonv1.KeyValue
 	DroppedAttributesCount uint32
-	Flags                  uint32
-	TraceId                []byte
-	SpanId                 []byte
-	EventName              string
+	// Flags, a bit field. 8 least significant bits are the trace flags as
+	// defined in W3C Trace Context specification. 24 most significant bits are reserved
+	// and must be set to 0. Readers must not assume that 24 most significant bits
+	// will be zero and must correctly mask the bits when reading 8-bit trace flag (use
+	// flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK). [Optional].
+	Flags uint32
+	// A unique identifier for a trace. All logs from the same trace share
+	// the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+	// of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+	// is zero-length and thus is also invalid).
+	//
+	// This field is optional.
+	//
+	// The receivers SHOULD assume that the log record is not associated with a
+	// trace if any of the following is true:
+	// - the field is not present,
+	// - the field contains an invalid value.
+	TraceId []byte
+	// A unique identifier for a span within a trace, assigned when the span
+	// is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+	// other than 8 bytes is considered invalid (empty string in OTLP/JSON
+	// is zero-length and thus is also invalid).
+	//
+	// This field is optional. If the sender specifies a valid span_id then it SHOULD also
+	// specify a valid trace_id.
+	//
+	// The receivers SHOULD assume that the log record is not associated with a
+	// span if any of the following is true:
+	// - the field is not present,
+	// - the field contains an invalid value.
+	SpanId []byte
+	// A unique identifier of event category/type.
+	// All events with the same event_name are expected to conform to the same
+	// schema for both their attributes and their body.
+	//
+	// Recommended to be fully qualified and short (no longer than 256 characters).
+	//
+	// Presence of event_name on the log record identifies this record
+	// as an event.
+	//
+	// [Optional].
+	EventName string
 }
 
 func (m *LogsData) Size() int {
@@ -168,10 +285,10 @@ func (m *LogRecord) Size() int {
 
 func (m *LogsData) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -201,10 +318,10 @@ func (m *LogsData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ResourceLogs) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -253,10 +370,10 @@ func (m *ResourceLogs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ScopeLogs) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -305,10 +422,10 @@ func (m *ScopeLogs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *LogRecord) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -971,4 +1088,166 @@ func (m *LogRecord) unmarshal(b []byte, depth int) error {
 		}
 	}
 	return nil
+}
+
+func (this *LogsData) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*LogsData)
+	if !ok {
+		that2, ok := that.(LogsData)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.ResourceLogs) != len(that1.ResourceLogs) {
+		return false
+	}
+	for i := range this.ResourceLogs {
+		if !this.ResourceLogs[i].Equal(that1.ResourceLogs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *ResourceLogs) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ResourceLogs)
+	if !ok {
+		that2, ok := that.(ResourceLogs)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Resource.Equal(that1.Resource) {
+		return false
+	}
+	if len(this.ScopeLogs) != len(that1.ScopeLogs) {
+		return false
+	}
+	for i := range this.ScopeLogs {
+		if !this.ScopeLogs[i].Equal(that1.ScopeLogs[i]) {
+			return false
+		}
+	}
+	if this.SchemaUrl != that1.SchemaUrl {
+		return false
+	}
+	return true
+}
+
+func (this *ScopeLogs) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ScopeLogs)
+	if !ok {
+		that2, ok := that.(ScopeLogs)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Scope.Equal(that1.Scope) {
+		return false
+	}
+	if len(this.LogRecords) != len(that1.LogRecords) {
+		return false
+	}
+	for i := range this.LogRecords {
+		if !this.LogRecords[i].Equal(that1.LogRecords[i]) {
+			return false
+		}
+	}
+	if this.SchemaUrl != that1.SchemaUrl {
+		return false
+	}
+	return true
+}
+
+func (this *LogRecord) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*LogRecord)
+	if !ok {
+		that2, ok := that.(LogRecord)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.TimeUnixNano != that1.TimeUnixNano {
+		return false
+	}
+	if this.ObservedTimeUnixNano != that1.ObservedTimeUnixNano {
+		return false
+	}
+	if this.SeverityNumber != that1.SeverityNumber {
+		return false
+	}
+	if this.SeverityText != that1.SeverityText {
+		return false
+	}
+	if !this.Body.Equal(that1.Body) {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.DroppedAttributesCount != that1.DroppedAttributesCount {
+		return false
+	}
+	if this.Flags != that1.Flags {
+		return false
+	}
+	if !bytes.Equal(this.TraceId, that1.TraceId) {
+		return false
+	}
+	if !bytes.Equal(this.SpanId, that1.SpanId) {
+		return false
+	}
+	if this.EventName != that1.EventName {
+		return false
+	}
+	return true
 }

--- a/gen/otlp/metrics/v1/metrics.go
+++ b/gen/otlp/metrics/v1/metrics.go
@@ -4343,8 +4343,54 @@ func (this *Metric) Equal(that interface{}) bool {
 	if this.Unit != that1.Unit {
 		return false
 	}
-	if this.Data != that1.Data {
+	if (this.Data == nil) != (that1.Data == nil) {
 		return false
+	}
+	if this.Data != nil {
+		switch v := this.Data.(type) {
+		case *Metric_Gauge:
+			v2, ok := that1.Data.(*Metric_Gauge)
+			if !ok {
+				return false
+			}
+			if !v.Gauge.Equal(v2.Gauge) {
+				return false
+			}
+		case *Metric_Sum:
+			v2, ok := that1.Data.(*Metric_Sum)
+			if !ok {
+				return false
+			}
+			if !v.Sum.Equal(v2.Sum) {
+				return false
+			}
+		case *Metric_Histogram:
+			v2, ok := that1.Data.(*Metric_Histogram)
+			if !ok {
+				return false
+			}
+			if !v.Histogram.Equal(v2.Histogram) {
+				return false
+			}
+		case *Metric_ExponentialHistogram:
+			v2, ok := that1.Data.(*Metric_ExponentialHistogram)
+			if !ok {
+				return false
+			}
+			if !v.ExponentialHistogram.Equal(v2.ExponentialHistogram) {
+				return false
+			}
+		case *Metric_Summary:
+			v2, ok := that1.Data.(*Metric_Summary)
+			if !ok {
+				return false
+			}
+			if !v.Summary.Equal(v2.Summary) {
+				return false
+			}
+		default:
+			return false
+		}
 	}
 	if len(this.Metadata) != len(that1.Metadata) {
 		return false
@@ -4552,8 +4598,30 @@ func (this *NumberDataPoint) Equal(that interface{}) bool {
 	if this.TimeUnixNano != that1.TimeUnixNano {
 		return false
 	}
-	if this.Value != that1.Value {
+	if (this.Value == nil) != (that1.Value == nil) {
 		return false
+	}
+	if this.Value != nil {
+		switch v := this.Value.(type) {
+		case *NumberDataPoint_AsDouble:
+			v2, ok := that1.Value.(*NumberDataPoint_AsDouble)
+			if !ok {
+				return false
+			}
+			if v.AsDouble != v2.AsDouble {
+				return false
+			}
+		case *NumberDataPoint_AsInt:
+			v2, ok := that1.Value.(*NumberDataPoint_AsInt)
+			if !ok {
+				return false
+			}
+			if v.AsInt != v2.AsInt {
+				return false
+			}
+		default:
+			return false
+		}
 	}
 	if len(this.Exemplars) != len(that1.Exemplars) {
 		return false
@@ -4892,8 +4960,30 @@ func (this *Exemplar) Equal(that interface{}) bool {
 	if this.TimeUnixNano != that1.TimeUnixNano {
 		return false
 	}
-	if this.Value != that1.Value {
+	if (this.Value == nil) != (that1.Value == nil) {
 		return false
+	}
+	if this.Value != nil {
+		switch v := this.Value.(type) {
+		case *Exemplar_AsDouble:
+			v2, ok := that1.Value.(*Exemplar_AsDouble)
+			if !ok {
+				return false
+			}
+			if v.AsDouble != v2.AsDouble {
+				return false
+			}
+		case *Exemplar_AsInt:
+			v2, ok := that1.Value.(*Exemplar_AsInt)
+			if !ok {
+				return false
+			}
+			if v.AsInt != v2.AsInt {
+				return false
+			}
+		default:
+			return false
+		}
 	}
 	if !bytes.Equal(this.SpanId, that1.SpanId) {
 		return false

--- a/gen/otlp/metrics/v1/metrics.go
+++ b/gen/otlp/metrics/v1/metrics.go
@@ -4,6 +4,7 @@
 package metricsv1
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -13,18 +14,92 @@ import (
 	"wiresmith/gen/protohelpers"
 )
 
+// AggregationTemporality defines how a metric aggregator reports aggregated
+// values. It describes how those values relate to the time interval over
+// which they are aggregated.
 type AggregationTemporality int32
 
 const (
+	// UNSPECIFIED is the default AggregationTemporality, it MUST not be used.
 	AGGREGATION_TEMPORALITY_UNSPECIFIED AggregationTemporality = 0
-	AGGREGATION_TEMPORALITY_DELTA       AggregationTemporality = 1
-	AGGREGATION_TEMPORALITY_CUMULATIVE  AggregationTemporality = 2
+	// DELTA is an AggregationTemporality for a metric aggregator which reports
+	// changes since last report time. Successive metrics contain aggregation of
+	// values from continuous and non-overlapping intervals.
+	//
+	// The values for a DELTA metric are based only on the time interval
+	// associated with one measurement cycle. There is no dependency on
+	// previous measurements like is the case for CUMULATIVE metrics.
+	//
+	// For example, consider a system measuring the number of requests that
+	// it receives and reports the sum of these requests every second as a
+	// DELTA metric:
+	//
+	// 1. The system starts receiving at time=t_0.
+	// 2. A request is received, the system measures 1 request.
+	// 3. A request is received, the system measures 1 request.
+	// 4. A request is received, the system measures 1 request.
+	// 5. The 1 second collection cycle ends. A metric is exported for the
+	// number of requests received over the interval of time t_0 to
+	// t_0+1 with a value of 3.
+	// 6. A request is received, the system measures 1 request.
+	// 7. A request is received, the system measures 1 request.
+	// 8. The 1 second collection cycle ends. A metric is exported for the
+	// number of requests received over the interval of time t_0+1 to
+	// t_0+2 with a value of 2.
+	AGGREGATION_TEMPORALITY_DELTA AggregationTemporality = 1
+	// CUMULATIVE is an AggregationTemporality for a metric aggregator which
+	// reports changes since a fixed start time. This means that current values
+	// of a CUMULATIVE metric depend on all previous measurements since the
+	// start time. Because of this, the sender is required to retain this state
+	// in some form. If this state is lost or invalidated, the CUMULATIVE metric
+	// values MUST be reset and a new fixed start time following the last
+	// reported measurement time sent MUST be used.
+	//
+	// For example, consider a system measuring the number of requests that
+	// it receives and reports the sum of these requests every second as a
+	// CUMULATIVE metric:
+	//
+	// 1. The system starts receiving at time=t_0.
+	// 2. A request is received, the system measures 1 request.
+	// 3. A request is received, the system measures 1 request.
+	// 4. A request is received, the system measures 1 request.
+	// 5. The 1 second collection cycle ends. A metric is exported for the
+	// number of requests received over the interval of time t_0 to
+	// t_0+1 with a value of 3.
+	// 6. A request is received, the system measures 1 request.
+	// 7. A request is received, the system measures 1 request.
+	// 8. The 1 second collection cycle ends. A metric is exported for the
+	// number of requests received over the interval of time t_0 to
+	// t_0+2 with a value of 5.
+	// 9. The system experiences a fault and loses state.
+	// 10. The system recovers and resumes receiving at time=t_1.
+	// 11. A request is received, the system measures 1 request.
+	// 12. The 1 second collection cycle ends. A metric is exported for the
+	// number of requests received over the interval of time t_1 to
+	// t_0+1 with a value of 1.
+	//
+	// Note: Even though, when reporting changes since last report time, using
+	// CUMULATIVE is valid, it is not recommended. This may cause problems for
+	// systems that do not use start_time to determine when the aggregation
+	// value was reset (e.g. Prometheus).
+	AGGREGATION_TEMPORALITY_CUMULATIVE AggregationTemporality = 2
 )
 
+// DataPointFlags is defined as a protobuf 'uint32' type and is to be used as a
+// bit-field representing 32 distinct boolean flags.  Each flag defined in this
+// enum is a bit-mask.  To test the presence of a single flag in the flags of
+// a data point, for example, use an expression like:
+//
+// (point.flags & DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK) == DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK
 type DataPointFlags int32
 
 const (
-	DATA_POINT_FLAGS_DO_NOT_USE             DataPointFlags = 0
+	// The zero value for the enum. Should not be used for comparisons.
+	// Instead use bitwise "and" with the appropriate mask as shown above.
+	DATA_POINT_FLAGS_DO_NOT_USE DataPointFlags = 0
+	// This DataPoint is valid but has no recorded value.  This value
+	// SHOULD be used to reflect explicitly missing data in a series, as
+	// for an equivalent to the Prometheus "staleness marker".
 	DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK DataPointFlags = 1
 )
 
@@ -94,120 +169,545 @@ type Exemplar_AsInt struct {
 
 func (*Exemplar_AsInt) isExemplar_Value() {}
 
+// MetricsData represents the metrics data that can be stored in a persistent
+// storage, OR can be embedded by other protocols that transfer OTLP metrics
+// data but do not implement the OTLP protocol.
+//
+// MetricsData
+// └─── ResourceMetrics
+// ├── Resource
+// ├── SchemaURL
+// └── ScopeMetrics
+// ├── Scope
+// ├── SchemaURL
+// └── Metric
+// ├── Name
+// ├── Description
+// ├── Unit
+// └── data
+// ├── Gauge
+// ├── Sum
+// ├── Histogram
+// ├── ExponentialHistogram
+// └── Summary
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
 type MetricsData struct {
+	// An array of ResourceMetrics.
+	// For data coming from a single resource this array will typically contain
+	// one element. Intermediary nodes that receive data from multiple origins
+	// typically batch the data before forwarding further and in that case this
+	// array will contain multiple elements.
 	ResourceMetrics []ResourceMetrics
 }
 
+// A collection of ScopeMetrics from a Resource.
 type ResourceMetrics struct {
-	Resource     resourcev1.Resource
+	// The resource for the metrics in this message.
+	// If this field is not set then no resource info is known.
+	Resource resourcev1.Resource
+	// A list of metrics that originate from a resource.
 	ScopeMetrics []ScopeMetrics
-	SchemaUrl    string
-}
-
-type ScopeMetrics struct {
-	Scope     commonv1.InstrumentationScope
-	Metrics   []Metric
+	// The Schema URL, if known. This is the identifier of the Schema that the resource data
+	// is recorded in. Notably, the last part of the URL path is the version number of the
+	// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	// This schema_url applies to the data in the "resource" field. It does not apply
+	// to the data in the "scope_metrics" field which have their own schema_url field.
 	SchemaUrl string
 }
 
-type Metric struct {
-	Name        string
-	Description string
-	Unit        string
-	Data        Metric_Data
-	Metadata    []commonv1.KeyValue
+// A collection of Metrics produced by an Scope.
+type ScopeMetrics struct {
+	// The instrumentation scope information for the metrics in this message.
+	// Semantically when InstrumentationScope isn't set, it is equivalent with
+	// an empty instrumentation scope name (unknown).
+	Scope commonv1.InstrumentationScope
+	// A list of metrics that originate from an instrumentation library.
+	Metrics []Metric
+	// The Schema URL, if known. This is the identifier of the Schema that the metric data
+	// is recorded in. Notably, the last part of the URL path is the version number of the
+	// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	// This schema_url applies to the data in the "scope" field and all metrics in the
+	// "metrics" field.
+	SchemaUrl string
 }
 
+// Defines a Metric which has one or more timeseries.  The following is a
+// brief summary of the Metric data model.  For more details, see:
+//
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md
+//
+// The data model and relation between entities is shown in the
+// diagram below. Here, "DataPoint" is the term used to refer to any
+// one of the specific data point value types, and "points" is the term used
+// to refer to any one of the lists of points contained in the Metric.
+//
+// - Metric is composed of a metadata and data.
+// - Metadata part contains a name, description, unit.
+// - Data is one of the possible types (Sum, Gauge, Histogram, Summary).
+// - DataPoint contains timestamps, attributes, and one of the possible value type
+// fields.
+//
+// Metric
+// +------------+
+// |name        |
+// |description |
+// |unit        |     +------------------------------------+
+// |data        |---> |Gauge, Sum, Histogram, Summary, ... |
+// +------------+     +------------------------------------+
+//
+// Data [One of Gauge, Sum, Histogram, Summary, ...]
+// +-----------+
+// |...        |  // Metadata about the Data.
+// |points     |--+
+// +-----------+  |
+// |      +---------------------------+
+// |      |DataPoint 1                |
+// v      |+------+------+   +------+ |
+// +-----+   ||label |label |...|label | |
+// |  1  |-->||value1|value2|...|valueN| |
+// +-----+   |+------+------+   +------+ |
+// |  .  |   |+-----+                    |
+// |  .  |   ||value|                    |
+// |  .  |   |+-----+                    |
+// |  .  |   +---------------------------+
+// |  .  |                   .
+// |  .  |                   .
+// |  .  |                   .
+// |  .  |   +---------------------------+
+// |  .  |   |DataPoint M                |
+// +-----+   |+------+------+   +------+ |
+// |  M  |-->||label |label |...|label | |
+// +-----+   ||value1|value2|...|valueN| |
+// |+------+------+   +------+ |
+// |+-----+                    |
+// ||value|                    |
+// |+-----+                    |
+// +---------------------------+
+//
+// Each distinct type of DataPoint represents the output of a specific
+// aggregation function, the result of applying the DataPoint's
+// associated function of to one or more measurements.
+//
+// All DataPoint types have three common fields:
+// - Attributes includes key-value pairs associated with the data point
+// - TimeUnixNano is required, set to the end time of the aggregation
+// - StartTimeUnixNano is optional, but strongly encouraged for DataPoints
+// having an AggregationTemporality field, as discussed below.
+//
+// Both TimeUnixNano and StartTimeUnixNano values are expressed as
+// UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+//
+// # TimeUnixNano
+//
+// This field is required, having consistent interpretation across
+// DataPoint types.  TimeUnixNano is the moment corresponding to when
+// the data point's aggregate value was captured.
+//
+// Data points with the 0 value for TimeUnixNano SHOULD be rejected
+// by consumers.
+//
+// # StartTimeUnixNano
+//
+// StartTimeUnixNano in general allows detecting when a sequence of
+// observations is unbroken.  This field indicates to consumers the
+// start time for points with cumulative and delta
+// AggregationTemporality, and it should be included whenever possible
+// to support correct rate calculation.  Although it may be omitted
+// when the start time is truly unknown, setting StartTimeUnixNano is
+// strongly encouraged.
+type Metric struct {
+	// The name of the metric.
+	Name string
+	// A description of the metric, which can be used in documentation.
+	Description string
+	// The unit in which the metric value is reported. Follows the format
+	// described by https://unitsofmeasure.org/ucum.html.
+	Unit string
+	// Data determines the aggregation type (if any) of the metric, what is the
+	// reported value type for the data points, as well as the relatationship to
+	// the time interval over which they are reported.
+	Data Metric_Data
+	// Additional metadata attributes that describe the metric. [Optional].
+	// Attributes are non-identifying.
+	// Consumers SHOULD NOT need to be aware of these attributes.
+	// These attributes MAY be used to encode information allowing
+	// for lossless roundtrip translation to / from another data model.
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Metadata []commonv1.KeyValue
+}
+
+// Gauge represents the type of a scalar metric that always exports the
+// "current value" for every data point. It should be used for an "unknown"
+// aggregation.
+//
+// A Gauge does not support different aggregation temporalities. Given the
+// aggregation is unknown, points cannot be combined using the same
+// aggregation, regardless of aggregation temporalities. Therefore,
+// AggregationTemporality is not included. Consequently, this also means
+// "StartTimeUnixNano" is ignored for all data points.
 type Gauge struct {
+	// The time series data points.
+	// Note: Multiple time series may be included (same timestamp, different attributes).
 	DataPoints []NumberDataPoint
 }
 
+// Sum represents the type of a scalar metric that is calculated as a sum of all
+// reported measurements over a time interval.
 type Sum struct {
-	DataPoints             []NumberDataPoint
+	// The time series data points.
+	// Note: Multiple time series may be included (same timestamp, different attributes).
+	DataPoints []NumberDataPoint
+	// aggregation_temporality describes if the aggregator reports delta changes
+	// since last report time, or cumulative changes since a fixed start time.
 	AggregationTemporality AggregationTemporality
-	IsMonotonic            bool
+	// Represents whether the sum is monotonic.
+	IsMonotonic bool
 }
 
+// Histogram represents the type of a metric that is calculated by aggregating
+// as a Histogram of all reported measurements over a time interval.
 type Histogram struct {
-	DataPoints             []HistogramDataPoint
+	// The time series data points.
+	// Note: Multiple time series may be included (same timestamp, different attributes).
+	DataPoints []HistogramDataPoint
+	// aggregation_temporality describes if the aggregator reports delta changes
+	// since last report time, or cumulative changes since a fixed start time.
 	AggregationTemporality AggregationTemporality
 }
 
+// ExponentialHistogram represents the type of a metric that is calculated by aggregating
+// as a ExponentialHistogram of all reported double measurements over a time interval.
 type ExponentialHistogram struct {
-	DataPoints             []ExponentialHistogramDataPoint
+	// The time series data points.
+	// Note: Multiple time series may be included (same timestamp, different attributes).
+	DataPoints []ExponentialHistogramDataPoint
+	// aggregation_temporality describes if the aggregator reports delta changes
+	// since last report time, or cumulative changes since a fixed start time.
 	AggregationTemporality AggregationTemporality
 }
 
+// Summary metric data are used to convey quantile summaries,
+// a Prometheus (see: https://prometheus.io/docs/concepts/metric_types/#summary)
+// and OpenMetrics (see: https://github.com/prometheus/OpenMetrics/blob/4dbf6075567ab43296eed941037c12951faafb92/protos/prometheus.proto#L45)
+// data type. These data points cannot always be merged in a meaningful way.
+// While they can be useful in some applications, histogram data points are
+// recommended for new applications.
+// Summary metrics do not have an aggregation temporality field. This is
+// because the count and sum fields of a SummaryDataPoint are assumed to be
+// cumulative values.
 type Summary struct {
+	// The time series data points.
+	// Note: Multiple time series may be included (same timestamp, different attributes).
 	DataPoints []SummaryDataPoint
 }
 
+// NumberDataPoint is a single data point in a timeseries that describes the
+// time-varying scalar value of a metric.
 type NumberDataPoint struct {
-	Attributes        []commonv1.KeyValue
+	// The set of key/value pairs that uniquely identify the timeseries from
+	// where this point belongs. The list may be empty (may contain 0 elements).
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Attributes []commonv1.KeyValue
+	// StartTimeUnixNano is optional but strongly encouraged, see the
+	// the detailed comments above Metric.
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+	// 1970.
 	StartTimeUnixNano uint64
-	TimeUnixNano      uint64
-	Value             NumberDataPoint_Value
-	Exemplars         []Exemplar
-	Flags             uint32
+	// TimeUnixNano is required, see the detailed comments above Metric.
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+	// 1970.
+	TimeUnixNano uint64
+	// The value itself.  A point is considered invalid when one of the recognized
+	// value fields is not present inside this oneof.
+	Value NumberDataPoint_Value
+	// (Optional) List of exemplars collected from
+	// measurements that were used to form the data point
+	Exemplars []Exemplar
+	// Flags that apply to this specific data point.  See DataPointFlags
+	// for the available flags and their meaning.
+	Flags uint32
 }
 
+// HistogramDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a Histogram. A Histogram contains summary statistics
+// for a population of values, it may optionally contain the distribution of
+// those values across a set of buckets.
+//
+// If the histogram contains the distribution of values, then both
+// "explicit_bounds" and "bucket counts" fields must be defined.
+// If the histogram does not contain the distribution of values, then both
+// "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
+// "sum" are known.
 type HistogramDataPoint struct {
-	Attributes        []commonv1.KeyValue
+	// The set of key/value pairs that uniquely identify the timeseries from
+	// where this point belongs. The list may be empty (may contain 0 elements).
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Attributes []commonv1.KeyValue
+	// StartTimeUnixNano is optional but strongly encouraged, see the
+	// the detailed comments above Metric.
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+	// 1970.
 	StartTimeUnixNano uint64
-	TimeUnixNano      uint64
-	Count             uint64
-	Sum               *float64
-	BucketCounts      []uint64
-	ExplicitBounds    []float64
-	Exemplars         []Exemplar
-	Flags             uint32
-	Min               *float64
-	Max               *float64
+	// TimeUnixNano is required, see the detailed comments above Metric.
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+	// 1970.
+	TimeUnixNano uint64
+	// count is the number of values in the population. Must be non-negative. This
+	// value must be equal to the sum of the "count" fields in buckets if a
+	// histogram is provided.
+	Count uint64
+	// sum of the values in the population. If count is zero then this field
+	// must be zero.
+	//
+	// Note: Sum should only be filled out when measuring non-negative discrete
+	// events, and is assumed to be monotonic over the values of these events.
+	// Negative events *can* be recorded, but sum should not be filled out when
+	// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+	// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
+	Sum *float64
+	// bucket_counts is an optional field contains the count values of histogram
+	// for each bucket.
+	//
+	// The sum of the bucket_counts must equal the value in the count field.
+	//
+	// The number of elements in bucket_counts array must be by one greater than
+	// the number of elements in explicit_bounds array. The exception to this rule
+	// is when the length of bucket_counts is 0, then the length of explicit_bounds
+	// must also be 0.
+	BucketCounts []uint64
+	// explicit_bounds specifies buckets with explicitly defined bounds for values.
+	//
+	// The boundaries for bucket at index i are:
+	//
+	// (-infinity, explicit_bounds[i]] for i == 0
+	// (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
+	// (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
+	//
+	// The values in the explicit_bounds array must be strictly increasing.
+	//
+	// Histogram buckets are inclusive of their upper boundary, except the last
+	// bucket where the boundary is at infinity. This format is intentionally
+	// compatible with the OpenMetrics histogram definition.
+	//
+	// If bucket_counts length is 0 then explicit_bounds length must also be 0,
+	// otherwise the data point is invalid.
+	ExplicitBounds []float64
+	// (Optional) List of exemplars collected from
+	// measurements that were used to form the data point
+	Exemplars []Exemplar
+	// Flags that apply to this specific data point.  See DataPointFlags
+	// for the available flags and their meaning.
+	Flags uint32
+	// min is the minimum value over (start_time, end_time].
+	Min *float64
+	// max is the maximum value over (start_time, end_time].
+	Max *float64
 }
 
+// Buckets are a set of bucket counts, encoded in a contiguous array
+// of counts.
 type ExponentialHistogramDataPoint_Buckets struct {
-	Offset       int32
+	// The bucket index of the first entry in the bucket_counts array.
+	//
+	// Note: This uses a varint encoding as a simple form of compression.
+	Offset int32
+	// An array of count values, where bucket_counts[i] carries
+	// the count of the bucket at index (offset+i). bucket_counts[i] is the count
+	// of values greater than base^(offset+i) and less than or equal to
+	// base^(offset+i+1).
+	//
+	// Note: By contrast, the explicit HistogramDataPoint uses
+	// fixed64.  This field is expected to have many buckets,
+	// especially zeros, so uint64 has been selected to ensure
+	// varint encoding.
 	BucketCounts []uint64
 }
 
+// ExponentialHistogramDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
+// summary statistics for a population of values, it may optionally contain the
+// distribution of those values across a set of buckets.
 type ExponentialHistogramDataPoint struct {
-	Attributes        []commonv1.KeyValue
+	// The set of key/value pairs that uniquely identify the timeseries from
+	// where this point belongs. The list may be empty (may contain 0 elements).
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Attributes []commonv1.KeyValue
+	// StartTimeUnixNano is optional but strongly encouraged, see the
+	// the detailed comments above Metric.
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+	// 1970.
 	StartTimeUnixNano uint64
-	TimeUnixNano      uint64
-	Count             uint64
-	Sum               *float64
-	Scale             int32
-	ZeroCount         uint64
-	Positive          ExponentialHistogramDataPoint_Buckets
-	Negative          ExponentialHistogramDataPoint_Buckets
-	Flags             uint32
-	Exemplars         []Exemplar
-	Min               *float64
-	Max               *float64
-	ZeroThreshold     float64
+	// TimeUnixNano is required, see the detailed comments above Metric.
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+	// 1970.
+	TimeUnixNano uint64
+	// The number of values in the population. Must be
+	// non-negative. This value must be equal to the sum of the "bucket_counts"
+	// values in the positive and negative Buckets plus the "zero_count" field.
+	Count uint64
+	// The sum of the values in the population. If count is zero then this field
+	// must be zero.
+	//
+	// Note: Sum should only be filled out when measuring non-negative discrete
+	// events, and is assumed to be monotonic over the values of these events.
+	// Negative events *can* be recorded, but sum should not be filled out when
+	// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+	// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
+	Sum *float64
+	// scale describes the resolution of the histogram.  Boundaries are
+	// located at powers of the base, where:
+	//
+	// base = (2^(2^-scale))
+	//
+	// The histogram bucket identified by `index`, a signed integer,
+	// contains values that are greater than (base^index) and
+	// less than or equal to (base^(index+1)).
+	//
+	// The positive and negative ranges of the histogram are expressed
+	// separately.  Negative values are mapped by their absolute value
+	// into the negative range using the same scale as the positive range.
+	//
+	// scale is not restricted by the protocol, as the permissible
+	// values depend on the range of the data.
+	Scale int32
+	// The count of values that are either exactly zero or
+	// within the region considered zero by the instrumentation at the
+	// tolerated degree of precision.  This bucket stores values that
+	// cannot be expressed using the standard exponential formula as
+	// well as values that have been rounded to zero.
+	//
+	// Implementations MAY consider the zero bucket to have probability
+	// mass equal to (zero_count / count).
+	ZeroCount uint64
+	// positive carries the positive range of exponential bucket counts.
+	Positive ExponentialHistogramDataPoint_Buckets
+	// negative carries the negative range of exponential bucket counts.
+	Negative ExponentialHistogramDataPoint_Buckets
+	// Flags that apply to this specific data point.  See DataPointFlags
+	// for the available flags and their meaning.
+	Flags uint32
+	// (Optional) List of exemplars collected from
+	// measurements that were used to form the data point
+	Exemplars []Exemplar
+	// The minimum value over (start_time, end_time].
+	Min *float64
+	// The maximum value over (start_time, end_time].
+	Max *float64
+	// ZeroThreshold may be optionally set to convey the width of the zero
+	// region. Where the zero region is defined as the closed interval
+	// [-ZeroThreshold, ZeroThreshold].
+	// When ZeroThreshold is 0, zero count bucket stores values that cannot be
+	// expressed using the standard exponential formula as well as values that
+	// have been rounded to zero.
+	ZeroThreshold float64
 }
 
+// Represents the value at a given quantile of a distribution.
+//
+// To record Min and Max values following conventions are used:
+// - The 1.0 quantile is equivalent to the maximum value observed.
+// - The 0.0 quantile is equivalent to the minimum value observed.
+//
+// See the following issue for more context:
+// https://github.com/open-telemetry/opentelemetry-proto/issues/125
 type SummaryDataPoint_ValueAtQuantile struct {
+	// The quantile of a distribution. Must be in the interval
+	// [0.0, 1.0].
 	Quantile float64
-	Value    float64
+	// The value at the given quantile of a distribution.
+	//
+	// Quantile values must NOT be negative.
+	Value float64
 }
 
+// SummaryDataPoint is a single data point in a timeseries that describes the
+// time-varying values of a Summary metric. The count and sum fields represent
+// cumulative values.
 type SummaryDataPoint struct {
-	Attributes        []commonv1.KeyValue
+	// The set of key/value pairs that uniquely identify the timeseries from
+	// where this point belongs. The list may be empty (may contain 0 elements).
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Attributes []commonv1.KeyValue
+	// StartTimeUnixNano is optional but strongly encouraged, see the
+	// the detailed comments above Metric.
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+	// 1970.
 	StartTimeUnixNano uint64
-	TimeUnixNano      uint64
-	Count             uint64
-	Sum               float64
-	QuantileValues    []SummaryDataPoint_ValueAtQuantile
-	Flags             uint32
+	// TimeUnixNano is required, see the detailed comments above Metric.
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+	// 1970.
+	TimeUnixNano uint64
+	// count is the number of values in the population. Must be non-negative.
+	Count uint64
+	// sum of the values in the population. If count is zero then this field
+	// must be zero.
+	//
+	// Note: Sum should only be filled out when measuring non-negative discrete
+	// events, and is assumed to be monotonic over the values of these events.
+	// Negative events *can* be recorded, but sum should not be filled out when
+	// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
+	// see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
+	Sum float64
+	// (Optional) list of values at different quantiles of the distribution calculated
+	// from the current snapshot. The quantiles must be strictly increasing.
+	QuantileValues []SummaryDataPoint_ValueAtQuantile
+	// Flags that apply to this specific data point.  See DataPointFlags
+	// for the available flags and their meaning.
+	Flags uint32
 }
 
+// A representation of an exemplar, which is a sample input measurement.
+// Exemplars also hold information about the environment when the measurement
+// was recorded, for example the span and trace ID of the active span when the
+// exemplar was recorded.
 type Exemplar struct {
+	// The set of key/value pairs that were filtered out by the aggregator, but
+	// recorded alongside the original measurement. Only key/value pairs that were
+	// filtered out by the aggregator should be included
 	FilteredAttributes []commonv1.KeyValue
-	TimeUnixNano       uint64
-	Value              Exemplar_Value
-	SpanId             []byte
-	TraceId            []byte
+	// time_unix_nano is the exact time when this exemplar was recorded
+	//
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
+	// 1970.
+	TimeUnixNano uint64
+	// The value of the measurement that was recorded. An exemplar is
+	// considered invalid when one of the recognized value fields is not present
+	// inside this oneof.
+	Value Exemplar_Value
+	// (Optional) Span ID of the exemplar trace.
+	// span_id may be missing if the measurement is not recorded inside a trace
+	// or if the trace is not sampled.
+	SpanId []byte
+	// (Optional) Trace ID of the exemplar trace.
+	// trace_id may be missing if the measurement is not recorded inside a trace
+	// or if the trace is not sampled.
+	TraceId []byte
 }
 
 func (m *MetricsData) Size() int {
@@ -556,10 +1056,10 @@ func (m *Exemplar) Size() int {
 
 func (m *MetricsData) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -589,10 +1089,10 @@ func (m *MetricsData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ResourceMetrics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -641,10 +1141,10 @@ func (m *ResourceMetrics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ScopeMetrics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -693,10 +1193,10 @@ func (m *ScopeMetrics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Metric) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -794,10 +1294,10 @@ func (m *Metric) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Gauge) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -827,10 +1327,10 @@ func (m *Gauge) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Sum) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -875,10 +1375,10 @@ func (m *Sum) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Histogram) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -913,10 +1413,10 @@ func (m *Histogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ExponentialHistogram) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -951,10 +1451,10 @@ func (m *ExponentialHistogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Summary) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -984,10 +1484,10 @@ func (m *Summary) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *NumberDataPoint) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1056,10 +1556,10 @@ func (m *NumberDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *HistogramDataPoint) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1158,10 +1658,10 @@ func (m *HistogramDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ExponentialHistogramDataPoint_Buckets) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1196,10 +1696,10 @@ func (m *ExponentialHistogramDataPoint_Buckets) MarshalToSizedBuffer(dAtA []byte
 
 func (m *ExponentialHistogramDataPoint) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1321,10 +1821,10 @@ func (m *ExponentialHistogramDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, 
 
 func (m *SummaryDataPoint_ValueAtQuantile) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1356,10 +1856,10 @@ func (m *SummaryDataPoint_ValueAtQuantile) MarshalToSizedBuffer(dAtA []byte) (in
 
 func (m *SummaryDataPoint) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1428,10 +1928,10 @@ func (m *SummaryDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Exemplar) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -3711,4 +4211,695 @@ func (m *Exemplar) unmarshal(b []byte, depth int) error {
 		}
 	}
 	return nil
+}
+
+func (this *MetricsData) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*MetricsData)
+	if !ok {
+		that2, ok := that.(MetricsData)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.ResourceMetrics) != len(that1.ResourceMetrics) {
+		return false
+	}
+	for i := range this.ResourceMetrics {
+		if !this.ResourceMetrics[i].Equal(that1.ResourceMetrics[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *ResourceMetrics) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ResourceMetrics)
+	if !ok {
+		that2, ok := that.(ResourceMetrics)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Resource.Equal(that1.Resource) {
+		return false
+	}
+	if len(this.ScopeMetrics) != len(that1.ScopeMetrics) {
+		return false
+	}
+	for i := range this.ScopeMetrics {
+		if !this.ScopeMetrics[i].Equal(that1.ScopeMetrics[i]) {
+			return false
+		}
+	}
+	if this.SchemaUrl != that1.SchemaUrl {
+		return false
+	}
+	return true
+}
+
+func (this *ScopeMetrics) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ScopeMetrics)
+	if !ok {
+		that2, ok := that.(ScopeMetrics)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Scope.Equal(that1.Scope) {
+		return false
+	}
+	if len(this.Metrics) != len(that1.Metrics) {
+		return false
+	}
+	for i := range this.Metrics {
+		if !this.Metrics[i].Equal(that1.Metrics[i]) {
+			return false
+		}
+	}
+	if this.SchemaUrl != that1.SchemaUrl {
+		return false
+	}
+	return true
+}
+
+func (this *Metric) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Metric)
+	if !ok {
+		that2, ok := that.(Metric)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Name != that1.Name {
+		return false
+	}
+	if this.Description != that1.Description {
+		return false
+	}
+	if this.Unit != that1.Unit {
+		return false
+	}
+	if this.Data != that1.Data {
+		return false
+	}
+	if len(this.Metadata) != len(that1.Metadata) {
+		return false
+	}
+	for i := range this.Metadata {
+		if !this.Metadata[i].Equal(that1.Metadata[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Gauge) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Gauge)
+	if !ok {
+		that2, ok := that.(Gauge)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.DataPoints) != len(that1.DataPoints) {
+		return false
+	}
+	for i := range this.DataPoints {
+		if !this.DataPoints[i].Equal(that1.DataPoints[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Sum) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Sum)
+	if !ok {
+		that2, ok := that.(Sum)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.DataPoints) != len(that1.DataPoints) {
+		return false
+	}
+	for i := range this.DataPoints {
+		if !this.DataPoints[i].Equal(that1.DataPoints[i]) {
+			return false
+		}
+	}
+	if this.AggregationTemporality != that1.AggregationTemporality {
+		return false
+	}
+	if this.IsMonotonic != that1.IsMonotonic {
+		return false
+	}
+	return true
+}
+
+func (this *Histogram) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Histogram)
+	if !ok {
+		that2, ok := that.(Histogram)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.DataPoints) != len(that1.DataPoints) {
+		return false
+	}
+	for i := range this.DataPoints {
+		if !this.DataPoints[i].Equal(that1.DataPoints[i]) {
+			return false
+		}
+	}
+	if this.AggregationTemporality != that1.AggregationTemporality {
+		return false
+	}
+	return true
+}
+
+func (this *ExponentialHistogram) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ExponentialHistogram)
+	if !ok {
+		that2, ok := that.(ExponentialHistogram)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.DataPoints) != len(that1.DataPoints) {
+		return false
+	}
+	for i := range this.DataPoints {
+		if !this.DataPoints[i].Equal(that1.DataPoints[i]) {
+			return false
+		}
+	}
+	if this.AggregationTemporality != that1.AggregationTemporality {
+		return false
+	}
+	return true
+}
+
+func (this *Summary) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Summary)
+	if !ok {
+		that2, ok := that.(Summary)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.DataPoints) != len(that1.DataPoints) {
+		return false
+	}
+	for i := range this.DataPoints {
+		if !this.DataPoints[i].Equal(that1.DataPoints[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *NumberDataPoint) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*NumberDataPoint)
+	if !ok {
+		that2, ok := that.(NumberDataPoint)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.StartTimeUnixNano != that1.StartTimeUnixNano {
+		return false
+	}
+	if this.TimeUnixNano != that1.TimeUnixNano {
+		return false
+	}
+	if this.Value != that1.Value {
+		return false
+	}
+	if len(this.Exemplars) != len(that1.Exemplars) {
+		return false
+	}
+	for i := range this.Exemplars {
+		if !this.Exemplars[i].Equal(that1.Exemplars[i]) {
+			return false
+		}
+	}
+	if this.Flags != that1.Flags {
+		return false
+	}
+	return true
+}
+
+func (this *HistogramDataPoint) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*HistogramDataPoint)
+	if !ok {
+		that2, ok := that.(HistogramDataPoint)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.StartTimeUnixNano != that1.StartTimeUnixNano {
+		return false
+	}
+	if this.TimeUnixNano != that1.TimeUnixNano {
+		return false
+	}
+	if this.Count != that1.Count {
+		return false
+	}
+	if this.Sum != that1.Sum {
+		if this.Sum == nil || that1.Sum == nil {
+			return false
+		}
+		if *this.Sum != *that1.Sum {
+			return false
+		}
+	}
+	if len(this.BucketCounts) != len(that1.BucketCounts) {
+		return false
+	}
+	for i := range this.BucketCounts {
+		if this.BucketCounts[i] != that1.BucketCounts[i] {
+			return false
+		}
+	}
+	if len(this.ExplicitBounds) != len(that1.ExplicitBounds) {
+		return false
+	}
+	for i := range this.ExplicitBounds {
+		if this.ExplicitBounds[i] != that1.ExplicitBounds[i] {
+			return false
+		}
+	}
+	if len(this.Exemplars) != len(that1.Exemplars) {
+		return false
+	}
+	for i := range this.Exemplars {
+		if !this.Exemplars[i].Equal(that1.Exemplars[i]) {
+			return false
+		}
+	}
+	if this.Flags != that1.Flags {
+		return false
+	}
+	if this.Min != that1.Min {
+		if this.Min == nil || that1.Min == nil {
+			return false
+		}
+		if *this.Min != *that1.Min {
+			return false
+		}
+	}
+	if this.Max != that1.Max {
+		if this.Max == nil || that1.Max == nil {
+			return false
+		}
+		if *this.Max != *that1.Max {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *ExponentialHistogramDataPoint_Buckets) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ExponentialHistogramDataPoint_Buckets)
+	if !ok {
+		that2, ok := that.(ExponentialHistogramDataPoint_Buckets)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Offset != that1.Offset {
+		return false
+	}
+	if len(this.BucketCounts) != len(that1.BucketCounts) {
+		return false
+	}
+	for i := range this.BucketCounts {
+		if this.BucketCounts[i] != that1.BucketCounts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *ExponentialHistogramDataPoint) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ExponentialHistogramDataPoint)
+	if !ok {
+		that2, ok := that.(ExponentialHistogramDataPoint)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.StartTimeUnixNano != that1.StartTimeUnixNano {
+		return false
+	}
+	if this.TimeUnixNano != that1.TimeUnixNano {
+		return false
+	}
+	if this.Count != that1.Count {
+		return false
+	}
+	if this.Sum != that1.Sum {
+		if this.Sum == nil || that1.Sum == nil {
+			return false
+		}
+		if *this.Sum != *that1.Sum {
+			return false
+		}
+	}
+	if this.Scale != that1.Scale {
+		return false
+	}
+	if this.ZeroCount != that1.ZeroCount {
+		return false
+	}
+	if !this.Positive.Equal(that1.Positive) {
+		return false
+	}
+	if !this.Negative.Equal(that1.Negative) {
+		return false
+	}
+	if this.Flags != that1.Flags {
+		return false
+	}
+	if len(this.Exemplars) != len(that1.Exemplars) {
+		return false
+	}
+	for i := range this.Exemplars {
+		if !this.Exemplars[i].Equal(that1.Exemplars[i]) {
+			return false
+		}
+	}
+	if this.Min != that1.Min {
+		if this.Min == nil || that1.Min == nil {
+			return false
+		}
+		if *this.Min != *that1.Min {
+			return false
+		}
+	}
+	if this.Max != that1.Max {
+		if this.Max == nil || that1.Max == nil {
+			return false
+		}
+		if *this.Max != *that1.Max {
+			return false
+		}
+	}
+	if this.ZeroThreshold != that1.ZeroThreshold {
+		return false
+	}
+	return true
+}
+
+func (this *SummaryDataPoint_ValueAtQuantile) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*SummaryDataPoint_ValueAtQuantile)
+	if !ok {
+		that2, ok := that.(SummaryDataPoint_ValueAtQuantile)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Quantile != that1.Quantile {
+		return false
+	}
+	if this.Value != that1.Value {
+		return false
+	}
+	return true
+}
+
+func (this *SummaryDataPoint) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*SummaryDataPoint)
+	if !ok {
+		that2, ok := that.(SummaryDataPoint)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.StartTimeUnixNano != that1.StartTimeUnixNano {
+		return false
+	}
+	if this.TimeUnixNano != that1.TimeUnixNano {
+		return false
+	}
+	if this.Count != that1.Count {
+		return false
+	}
+	if this.Sum != that1.Sum {
+		return false
+	}
+	if len(this.QuantileValues) != len(that1.QuantileValues) {
+		return false
+	}
+	for i := range this.QuantileValues {
+		if !this.QuantileValues[i].Equal(that1.QuantileValues[i]) {
+			return false
+		}
+	}
+	if this.Flags != that1.Flags {
+		return false
+	}
+	return true
+}
+
+func (this *Exemplar) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Exemplar)
+	if !ok {
+		that2, ok := that.(Exemplar)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.FilteredAttributes) != len(that1.FilteredAttributes) {
+		return false
+	}
+	for i := range this.FilteredAttributes {
+		if !this.FilteredAttributes[i].Equal(that1.FilteredAttributes[i]) {
+			return false
+		}
+	}
+	if this.TimeUnixNano != that1.TimeUnixNano {
+		return false
+	}
+	if this.Value != that1.Value {
+		return false
+	}
+	if !bytes.Equal(this.SpanId, that1.SpanId) {
+		return false
+	}
+	if !bytes.Equal(this.TraceId, that1.TraceId) {
+		return false
+	}
+	return true
 }

--- a/gen/otlp/profiles/v1development/profiles.go
+++ b/gen/otlp/profiles/v1development/profiles.go
@@ -4,6 +4,7 @@
 package profilesv1development
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -12,100 +13,379 @@ import (
 	"wiresmith/gen/protohelpers"
 )
 
+// ProfilesDictionary represents the profiles data shared across the
+// entire message being sent. The following applies to all fields in this
+// message:
+//
+// - A dictionary is an array of dictionary items. Users of the dictionary
+// compactly reference the items using the index within the array.
+//
+// - A dictionary MUST have a zero value encoded as the first element. This
+// allows for _index fields pointing into the dictionary to use a 0 pointer
+// value to indicate 'null' / 'not set'. Unless otherwise defined, a 'zero
+// value' message value is one with all default field values, so as to
+// minimize wire encoded size.
+//
+// - There SHOULD NOT be dupes in a dictionary. The identity of dictionary
+// items is based on their value, recursively as needed. If a particular
+// implementation does emit duplicated items, it MUST NOT attempt to give them
+// meaning based on the index or order. A profile processor may remove
+// duplicate items and this MUST NOT have any observable effects for
+// consumers.
+//
+// - There SHOULD NOT be orphaned (unreferenced) items in a dictionary. A
+// profile processor may remove ("garbage-collect") orphaned items and this
+// MUST NOT have any observable effects for consumers.
+//
+// Status: [Alpha]
 type ProfilesDictionary struct {
-	MappingTable   []Mapping
-	LocationTable  []Location
-	FunctionTable  []Function
-	LinkTable      []Link
-	StringTable    []string
+	// Mappings from address ranges to the image/binary/library mapped
+	// into that address range referenced by locations via Location.mapping_index.
+	//
+	// mapping_table[0] must always be zero value (Mapping{}) and present.
+	MappingTable []Mapping
+	// Locations referenced by samples via Stack.location_indices.
+	//
+	// location_table[0] must always be zero value (Location{}) and present.
+	LocationTable []Location
+	// Functions referenced by locations via Line.function_index.
+	//
+	// function_table[0] must always be zero value (Function{}) and present.
+	FunctionTable []Function
+	// Links referenced by samples via Sample.link_index.
+	//
+	// link_table[0] must always be zero value (Link{}) and present.
+	LinkTable []Link
+	// A common table for strings referenced by various messages.
+	//
+	// string_table[0] must always be "" and present.
+	StringTable []string
+	// A common table for attributes referenced by the Profile, Sample, Mapping
+	// and Location messages below through attribute_indices field. Each entry is
+	// a key/value pair with an optional unit. Since this is a dictionary table,
+	// multiple entries with the same key may be present, unlike direct attribute
+	// tables like Resource.attributes. The referencing attribute_indices fields,
+	// though, do maintain the key uniqueness requirement.
+	//
+	// It's recommended to use attributes for variables with bounded cardinality,
+	// such as categorical variables
+	// (https://en.wikipedia.org/wiki/Categorical_variable). Using an attribute of
+	// a floating point type (e.g., CPU time) in a sample can quickly make every
+	// attribute value unique, defeating the purpose of the dictionary and
+	// impractically increasing the profile size.
+	//
+	// Examples of attributes:
+	// "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+	// "abc.com/myattribute": true
+	// "allocation_size": 128 bytes
+	//
+	// attribute_table[0] must always be zero value (KeyValueAndUnit{}) and present.
 	AttributeTable []KeyValueAndUnit
-	StackTable     []Stack
+	// Stacks referenced by samples via Sample.stack_index.
+	//
+	// stack_table[0] must always be zero value (Stack{}) and present.
+	StackTable []Stack
 }
 
+// ProfilesData represents the profiles data that can be stored in persistent storage,
+// OR can be embedded by other protocols that transfer OTLP profiles data but do not
+// implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
+//
+// Status: [Alpha]
 type ProfilesData struct {
+	// An array of ResourceProfiles.
+	// For data coming from an SDK profiler, this array will typically contain one
+	// element. Host-level profilers will usually create one ResourceProfile per
+	// container, as well as one additional ResourceProfile grouping all samples
+	// from non-containerized processes.
+	// Other resource groupings are possible as well and clarified via
+	// Resource.attributes and semantic conventions.
+	// Tools that visualize profiles should prefer displaying
+	// resources_profiles[0].scope_profiles[0].profiles[0] by default.
 	ResourceProfiles []ResourceProfiles
-	Dictionary       ProfilesDictionary
+	// One instance of ProfilesDictionary
+	Dictionary ProfilesDictionary
 }
 
+// A collection of ScopeProfiles from a Resource.
+//
+// Status: [Alpha]
 type ResourceProfiles struct {
-	Resource      resourcev1.Resource
+	// The resource for the profiles in this message.
+	// If this field is not set then no resource info is known.
+	Resource resourcev1.Resource
+	// A list of ScopeProfiles that originate from a resource.
 	ScopeProfiles []ScopeProfiles
-	SchemaUrl     string
-}
-
-type ScopeProfiles struct {
-	Scope     commonv1.InstrumentationScope
-	Profiles  []Profile
+	// The Schema URL, if known. This is the identifier of the Schema that the resource data
+	// is recorded in. Notably, the last part of the URL path is the version number of the
+	// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	// This schema_url applies to the data in the "resource" field. It does not apply
+	// to the data in the "scope_profiles" field which have their own schema_url field.
 	SchemaUrl string
 }
 
+// A collection of Profiles produced by an InstrumentationScope.
+//
+// Status: [Alpha]
+type ScopeProfiles struct {
+	// The instrumentation scope information for the profiles in this message.
+	// Semantically when InstrumentationScope isn't set, it is equivalent with
+	// an empty instrumentation scope name (unknown).
+	Scope commonv1.InstrumentationScope
+	// A list of Profiles that originate from an instrumentation scope.
+	Profiles []Profile
+	// The Schema URL, if known. This is the identifier of the Schema that the profile data
+	// is recorded in. Notably, the last part of the URL path is the version number of the
+	// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	// This schema_url applies to the data in the "scope" field and all profiles in the
+	// "profiles" field.
+	SchemaUrl string
+}
+
+// Represents a complete profile, including sample types, samples, mappings to
+// binaries, stacks, locations, functions, string table, and additional
+// metadata. It modifies and annotates pprof Profile with OpenTelemetry
+// specific fields.
+//
+// Note that whilst fields in this message retain the name and field id from pprof in most cases
+// for ease of understanding data migration, it is not intended that pprof:Profile and
+// OpenTelemetry:Profile encoding be wire compatible.
+//
+// Status: [Alpha]
 type Profile struct {
-	SampleType             ValueType
-	Samples                []Sample
-	TimeUnixNano           uint64
-	DurationNano           uint64
-	PeriodType             ValueType
-	Period                 int64
-	ProfileId              []byte
+	// The type and unit of all Sample.values in this profile.
+	// For a cpu or off-cpu profile this might be:
+	// ["cpu","nanoseconds"] or ["off_cpu","nanoseconds"]
+	// For a heap profile, this might be:
+	// ["allocated_objects","count"] or ["allocated_space","bytes"],
+	SampleType ValueType
+	// The set of samples recorded in this profile.
+	Samples []Sample
+	// Time of collection. Value is UNIX Epoch time in nanoseconds since 00:00:00
+	// UTC on 1 January 1970.
+	TimeUnixNano uint64
+	// Duration of the profile. For instant profiles like live heap snapshot, the
+	// duration can be zero but it may be preferable to set time_unix_nano to the
+	// process start time and duration_nano to the relative time when the profile
+	// was gathered. This ensures Sample.timestamps_unix_nano values such as
+	// allocation timestamp fall into the profile time range.
+	DurationNano uint64
+	// The kind of events between sampled occurrences.
+	// e.g [ "cpu","cycles" ] or [ "heap","bytes" ]
+	PeriodType ValueType
+	// The number of events between sampled occurrences.
+	Period int64
+	// A globally unique identifier for a profile. The ID is a 16-byte array. An ID with
+	// all zeroes is considered invalid. It may be used for deduplication and signal
+	// correlation purposes. It is acceptable to treat two profiles with different values
+	// in this field as not equal, even if they represented the same object at an earlier
+	// time.
+	// This field is optional; an ID may be assigned to an ID-less profile in a later step.
+	ProfileId []byte
+	// The number of attributes that were discarded. Attributes
+	// can be discarded because their keys are too long or because there are too many
+	// attributes. If this value is 0, then no attributes were dropped.
 	DroppedAttributesCount uint32
-	OriginalPayloadFormat  string
-	OriginalPayload        []byte
-	AttributeIndices       []int32
+	// The original payload format. See also original_payload. Optional, but the
+	// format and the bytes must be set or unset together.
+	//
+	// The allowed values for the format string are defined by the OpenTelemetry
+	// specification. Some examples are "jfr", "pprof", "linux_perf".
+	//
+	// The original payload may be optionally provided when the conversion to the
+	// OLTP format was done from a different format with some loss of the fidelity
+	// and the receiver may want to store the original payload to allow future
+	// lossless export or reinterpretation. Some examples of the original format
+	// are JFR (Java Flight Recorder), pprof, Linux perf.
+	//
+	// Even when the original payload is in a format that is semantically close to
+	// OTLP, such as pprof, a conversion may still be lossy in some cases (e.g. if
+	// the pprof file contains custom extensions or conventions).
+	//
+	// The original payload can be large in size, so including the original
+	// payload should be configurable by the profiler or collector options. The
+	// default behavior should be to not include the original payload.
+	OriginalPayloadFormat string
+	// The original payload bytes. See also original_payload_format. Optional, but
+	// format and the bytes must be set or unset together.
+	OriginalPayload []byte
+	// References to attributes in attribute_table. [optional]
+	AttributeIndices []int32
 }
 
+// A pointer from a profile Sample to a trace Span.
+// Connects a profile sample to a trace span, identified by unique trace and span IDs.
+//
+// Status: [Alpha]
 type Link struct {
+	// A unique identifier of a trace that this linked span is part of. The ID is a
+	// 16-byte array.
 	TraceId []byte
-	SpanId  []byte
+	// A unique identifier for the linked span. The ID is an 8-byte array.
+	SpanId []byte
 }
 
+// ValueType describes the type and units of a value.
+//
+// Status: [Alpha]
 type ValueType struct {
+	// Index into ProfilesDictionary.string_table.
 	TypeStrindex int32
+	// Index into ProfilesDictionary.string_table.
 	UnitStrindex int32
 }
 
+// Each Sample records values encountered in some program context. The program
+// context is typically a stack trace, perhaps augmented with auxiliary
+// information like the thread-id, some indicator of a higher level request
+// being handled etc.
+//
+// A Sample MUST have have at least one values or timestamps_unix_nano entry. If
+// both fields are populated, they MUST contain the same number of elements, and
+// the elements at the same index MUST refer to the same event.
+//
+// For the purposes of efficiently representing aggregated data observations, a Sample is regarded
+// as having a shared identity and an associated collection of per-observation data points.
+// Samples having the same identity SHOULD be combined by inserting timestamps and values to the data arrays.
+//
+// Examples of different ways ('shapes') of representing a sample with the total value of 10:
+//
+// Report of a stacktrace at 10 timestamps (consumers must assume the value is 1 for each point):
+// values: []
+// timestamps_unix_nano: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+//
+// Report of a stacktrace with an aggregated value without timestamps:
+// values: [10]
+// timestamps_unix_nano: []
+//
+// Report of a stacktrace at 4 timestamps where each point records a specific value:
+// values: [2, 2, 3, 3]
+// timestamps_unix_nano: [1, 2, 3, 4]
+//
+// All Samples for a Profile SHOULD have the same shape, i.e. all data observation series should consistently
+// adopt the same data recording style.
+//
+// Status: [Alpha]
 type Sample struct {
-	StackIndex         int32
-	AttributeIndices   []int32
-	LinkIndex          int32
-	Values             []int64
+	// Reference to stack in ProfilesDictionary.stack_table.
+	StackIndex int32
+	// References to attributes in ProfilesDictionary.attribute_table. [optional]
+	AttributeIndices []int32
+	// Reference to link in ProfilesDictionary.link_table. [optional]
+	// It can be unset / set to 0 if no link exists, as link_table[0] is always a 'null' default value.
+	LinkIndex int32
+	// The type and unit of each value is defined by Profile.sample_type.
+	Values []int64
+	// Timestamps associated with Sample. Value is UNIX Epoch time in nanoseconds
+	// since 00:00:00 UTC on 1 January 1970. The timestamps should fall within the
+	// [Profile.time_unix_nano, Profile.time_unix_nano + Profile.duration_nano)
+	// time range.
 	TimestampsUnixNano []uint64
 }
 
+// Describes the mapping of a binary in memory, including its address range,
+// file offset, and metadata like build ID
+//
+// Status: [Alpha]
 type Mapping struct {
-	MemoryStart      uint64
-	MemoryLimit      uint64
-	FileOffset       uint64
+	// Address at which the binary (or DLL) is loaded into memory.
+	MemoryStart uint64
+	// The limit of the address range occupied by this mapping.
+	MemoryLimit uint64
+	// Offset in the binary that corresponds to the first mapped address.
+	FileOffset uint64
+	// The object this entry is loaded from.  This can be a filename on
+	// disk for the main binary and shared libraries, or virtual
+	// abstractions like "[vdso]".
 	FilenameStrindex int32
+	// References to attributes in ProfilesDictionary.attribute_table. [optional]
 	AttributeIndices []int32
 }
 
+// A Stack represents a stack trace as a list of locations.
+//
+// Status: [Alpha]
 type Stack struct {
+	// References to locations in ProfilesDictionary.location_table.
+	// The first location is the leaf frame.
 	LocationIndices []int32
 }
 
+// Describes function and line table debug information.
+//
+// Status: [Alpha]
 type Location struct {
-	MappingIndex     int32
-	Address          uint64
-	Lines            []Line
+	// Reference to mapping in ProfilesDictionary.mapping_table.
+	// It can be unset / set to 0 if the mapping is unknown or not applicable for
+	// this profile type, as mapping_table[0] is always a 'null' default mapping.
+	MappingIndex int32
+	// The instruction address for this location, if available.  It
+	// should be within [Mapping.memory_start...Mapping.memory_limit]
+	// for the corresponding mapping. A non-leaf address may be in the
+	// middle of a call instruction. It is up to display tools to find
+	// the beginning of the instruction if necessary.
+	Address uint64
+	// Multiple line indicates this location has inlined functions,
+	// where the last entry represents the caller into which the
+	// preceding entries were inlined.
+	//
+	// E.g., if memcpy() is inlined into printf:
+	// lines[0].function_name == "memcpy"
+	// lines[1].function_name == "printf"
+	Lines []Line
+	// References to attributes in ProfilesDictionary.attribute_table. [optional]
 	AttributeIndices []int32
 }
 
+// Details a specific line in a source code, linked to a function.
+//
+// Status: [Alpha]
 type Line struct {
+	// Reference to function in ProfilesDictionary.function_table.
 	FunctionIndex int32
-	Line          int64
-	Column        int64
+	// Line number in source code. 0 means unset.
+	Line int64
+	// Column number in source code. 0 means unset.
+	Column int64
 }
 
+// Describes a function, including its human-readable name, system name,
+// source file, and starting line number in the source.
+//
+// Status: [Alpha]
 type Function struct {
-	NameStrindex       int32
+	// The function name. Empty string if not available.
+	NameStrindex int32
+	// Function name, as identified by the system. For instance,
+	// it can be a C++ mangled name. Empty string if not available.
 	SystemNameStrindex int32
-	FilenameStrindex   int32
-	StartLine          int64
+	// Source file containing the function. Empty string if not available.
+	FilenameStrindex int32
+	// Line number in source file. 0 means unset.
+	StartLine int64
 }
 
+// A custom 'dictionary native' style of encoding attributes which is more convenient
+// for profiles than opentelemetry.proto.common.v1.KeyValue
+// Specifically, uses the string table for keys and allows optional unit information.
+//
+// Status: [Alpha]
 type KeyValueAndUnit struct {
-	KeyStrindex  int32
-	Value        commonv1.AnyValue
+	// The index into the string table for the attribute's key.
+	KeyStrindex int32
+	// The value of the attribute.
+	Value commonv1.AnyValue
+	// The index into the string table for the attribute's unit.
+	// zero indicates implicit (by semconv) or non-defined unit.
 	UnitStrindex int32
 }
 
@@ -400,10 +680,10 @@ func (m *KeyValueAndUnit) Size() int {
 
 func (m *ProfilesDictionary) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -490,10 +770,10 @@ func (m *ProfilesDictionary) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ProfilesData) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -535,10 +815,10 @@ func (m *ProfilesData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ResourceProfiles) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -587,10 +867,10 @@ func (m *ResourceProfiles) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ScopeProfiles) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -639,10 +919,10 @@ func (m *ScopeProfiles) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Profile) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -748,10 +1028,10 @@ func (m *Profile) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Link) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -785,10 +1065,10 @@ func (m *Link) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ValueType) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -818,10 +1098,10 @@ func (m *ValueType) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Sample) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -880,10 +1160,10 @@ func (m *Sample) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Mapping) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -933,10 +1213,10 @@ func (m *Mapping) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Stack) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -966,10 +1246,10 @@ func (m *Stack) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Location) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1019,10 +1299,10 @@ func (m *Location) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Line) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1057,10 +1337,10 @@ func (m *Line) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Function) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1100,10 +1380,10 @@ func (m *Function) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *KeyValueAndUnit) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -2813,4 +3093,572 @@ func (m *KeyValueAndUnit) unmarshal(b []byte, depth int) error {
 		}
 	}
 	return nil
+}
+
+func (this *ProfilesDictionary) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ProfilesDictionary)
+	if !ok {
+		that2, ok := that.(ProfilesDictionary)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.MappingTable) != len(that1.MappingTable) {
+		return false
+	}
+	for i := range this.MappingTable {
+		if !this.MappingTable[i].Equal(that1.MappingTable[i]) {
+			return false
+		}
+	}
+	if len(this.LocationTable) != len(that1.LocationTable) {
+		return false
+	}
+	for i := range this.LocationTable {
+		if !this.LocationTable[i].Equal(that1.LocationTable[i]) {
+			return false
+		}
+	}
+	if len(this.FunctionTable) != len(that1.FunctionTable) {
+		return false
+	}
+	for i := range this.FunctionTable {
+		if !this.FunctionTable[i].Equal(that1.FunctionTable[i]) {
+			return false
+		}
+	}
+	if len(this.LinkTable) != len(that1.LinkTable) {
+		return false
+	}
+	for i := range this.LinkTable {
+		if !this.LinkTable[i].Equal(that1.LinkTable[i]) {
+			return false
+		}
+	}
+	if len(this.StringTable) != len(that1.StringTable) {
+		return false
+	}
+	for i := range this.StringTable {
+		if this.StringTable[i] != that1.StringTable[i] {
+			return false
+		}
+	}
+	if len(this.AttributeTable) != len(that1.AttributeTable) {
+		return false
+	}
+	for i := range this.AttributeTable {
+		if !this.AttributeTable[i].Equal(that1.AttributeTable[i]) {
+			return false
+		}
+	}
+	if len(this.StackTable) != len(that1.StackTable) {
+		return false
+	}
+	for i := range this.StackTable {
+		if !this.StackTable[i].Equal(that1.StackTable[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *ProfilesData) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ProfilesData)
+	if !ok {
+		that2, ok := that.(ProfilesData)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.ResourceProfiles) != len(that1.ResourceProfiles) {
+		return false
+	}
+	for i := range this.ResourceProfiles {
+		if !this.ResourceProfiles[i].Equal(that1.ResourceProfiles[i]) {
+			return false
+		}
+	}
+	if !this.Dictionary.Equal(that1.Dictionary) {
+		return false
+	}
+	return true
+}
+
+func (this *ResourceProfiles) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ResourceProfiles)
+	if !ok {
+		that2, ok := that.(ResourceProfiles)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Resource.Equal(that1.Resource) {
+		return false
+	}
+	if len(this.ScopeProfiles) != len(that1.ScopeProfiles) {
+		return false
+	}
+	for i := range this.ScopeProfiles {
+		if !this.ScopeProfiles[i].Equal(that1.ScopeProfiles[i]) {
+			return false
+		}
+	}
+	if this.SchemaUrl != that1.SchemaUrl {
+		return false
+	}
+	return true
+}
+
+func (this *ScopeProfiles) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ScopeProfiles)
+	if !ok {
+		that2, ok := that.(ScopeProfiles)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Scope.Equal(that1.Scope) {
+		return false
+	}
+	if len(this.Profiles) != len(that1.Profiles) {
+		return false
+	}
+	for i := range this.Profiles {
+		if !this.Profiles[i].Equal(that1.Profiles[i]) {
+			return false
+		}
+	}
+	if this.SchemaUrl != that1.SchemaUrl {
+		return false
+	}
+	return true
+}
+
+func (this *Profile) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Profile)
+	if !ok {
+		that2, ok := that.(Profile)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.SampleType.Equal(that1.SampleType) {
+		return false
+	}
+	if len(this.Samples) != len(that1.Samples) {
+		return false
+	}
+	for i := range this.Samples {
+		if !this.Samples[i].Equal(that1.Samples[i]) {
+			return false
+		}
+	}
+	if this.TimeUnixNano != that1.TimeUnixNano {
+		return false
+	}
+	if this.DurationNano != that1.DurationNano {
+		return false
+	}
+	if !this.PeriodType.Equal(that1.PeriodType) {
+		return false
+	}
+	if this.Period != that1.Period {
+		return false
+	}
+	if !bytes.Equal(this.ProfileId, that1.ProfileId) {
+		return false
+	}
+	if this.DroppedAttributesCount != that1.DroppedAttributesCount {
+		return false
+	}
+	if this.OriginalPayloadFormat != that1.OriginalPayloadFormat {
+		return false
+	}
+	if !bytes.Equal(this.OriginalPayload, that1.OriginalPayload) {
+		return false
+	}
+	if len(this.AttributeIndices) != len(that1.AttributeIndices) {
+		return false
+	}
+	for i := range this.AttributeIndices {
+		if this.AttributeIndices[i] != that1.AttributeIndices[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Link) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Link)
+	if !ok {
+		that2, ok := that.(Link)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !bytes.Equal(this.TraceId, that1.TraceId) {
+		return false
+	}
+	if !bytes.Equal(this.SpanId, that1.SpanId) {
+		return false
+	}
+	return true
+}
+
+func (this *ValueType) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ValueType)
+	if !ok {
+		that2, ok := that.(ValueType)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.TypeStrindex != that1.TypeStrindex {
+		return false
+	}
+	if this.UnitStrindex != that1.UnitStrindex {
+		return false
+	}
+	return true
+}
+
+func (this *Sample) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Sample)
+	if !ok {
+		that2, ok := that.(Sample)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.StackIndex != that1.StackIndex {
+		return false
+	}
+	if len(this.AttributeIndices) != len(that1.AttributeIndices) {
+		return false
+	}
+	for i := range this.AttributeIndices {
+		if this.AttributeIndices[i] != that1.AttributeIndices[i] {
+			return false
+		}
+	}
+	if this.LinkIndex != that1.LinkIndex {
+		return false
+	}
+	if len(this.Values) != len(that1.Values) {
+		return false
+	}
+	for i := range this.Values {
+		if this.Values[i] != that1.Values[i] {
+			return false
+		}
+	}
+	if len(this.TimestampsUnixNano) != len(that1.TimestampsUnixNano) {
+		return false
+	}
+	for i := range this.TimestampsUnixNano {
+		if this.TimestampsUnixNano[i] != that1.TimestampsUnixNano[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Mapping) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Mapping)
+	if !ok {
+		that2, ok := that.(Mapping)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.MemoryStart != that1.MemoryStart {
+		return false
+	}
+	if this.MemoryLimit != that1.MemoryLimit {
+		return false
+	}
+	if this.FileOffset != that1.FileOffset {
+		return false
+	}
+	if this.FilenameStrindex != that1.FilenameStrindex {
+		return false
+	}
+	if len(this.AttributeIndices) != len(that1.AttributeIndices) {
+		return false
+	}
+	for i := range this.AttributeIndices {
+		if this.AttributeIndices[i] != that1.AttributeIndices[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Stack) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Stack)
+	if !ok {
+		that2, ok := that.(Stack)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.LocationIndices) != len(that1.LocationIndices) {
+		return false
+	}
+	for i := range this.LocationIndices {
+		if this.LocationIndices[i] != that1.LocationIndices[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Location) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Location)
+	if !ok {
+		that2, ok := that.(Location)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.MappingIndex != that1.MappingIndex {
+		return false
+	}
+	if this.Address != that1.Address {
+		return false
+	}
+	if len(this.Lines) != len(that1.Lines) {
+		return false
+	}
+	for i := range this.Lines {
+		if !this.Lines[i].Equal(that1.Lines[i]) {
+			return false
+		}
+	}
+	if len(this.AttributeIndices) != len(that1.AttributeIndices) {
+		return false
+	}
+	for i := range this.AttributeIndices {
+		if this.AttributeIndices[i] != that1.AttributeIndices[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Line) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Line)
+	if !ok {
+		that2, ok := that.(Line)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.FunctionIndex != that1.FunctionIndex {
+		return false
+	}
+	if this.Line != that1.Line {
+		return false
+	}
+	if this.Column != that1.Column {
+		return false
+	}
+	return true
+}
+
+func (this *Function) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Function)
+	if !ok {
+		that2, ok := that.(Function)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.NameStrindex != that1.NameStrindex {
+		return false
+	}
+	if this.SystemNameStrindex != that1.SystemNameStrindex {
+		return false
+	}
+	if this.FilenameStrindex != that1.FilenameStrindex {
+		return false
+	}
+	if this.StartLine != that1.StartLine {
+		return false
+	}
+	return true
+}
+
+func (this *KeyValueAndUnit) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*KeyValueAndUnit)
+	if !ok {
+		that2, ok := that.(KeyValueAndUnit)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.KeyStrindex != that1.KeyStrindex {
+		return false
+	}
+	if !this.Value.Equal(that1.Value) {
+		return false
+	}
+	if this.UnitStrindex != that1.UnitStrindex {
+		return false
+	}
+	return true
 }

--- a/gen/otlp/resource/v1/resource.go
+++ b/gen/otlp/resource/v1/resource.go
@@ -10,10 +10,22 @@ import (
 	"wiresmith/gen/protohelpers"
 )
 
+// Resource information.
 type Resource struct {
-	Attributes             []commonv1.KeyValue
+	// Set of attributes that describe the resource.
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Attributes []commonv1.KeyValue
+	// The number of dropped attributes. If the value is 0, then
+	// no attributes were dropped.
 	DroppedAttributesCount uint32
-	EntityRefs             []commonv1.EntityRef
+	// Set of entities that participate in this Resource.
+	//
+	// Note: keys in the references MUST exist in attributes of this message.
+	//
+	// Status: [Development]
+	EntityRefs []commonv1.EntityRef
 }
 
 func (m *Resource) Size() int {
@@ -34,10 +46,10 @@ func (m *Resource) Size() int {
 
 func (m *Resource) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -233,4 +245,45 @@ func (m *Resource) unmarshal(b []byte, depth int) error {
 		}
 	}
 	return nil
+}
+
+func (this *Resource) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Resource)
+	if !ok {
+		that2, ok := that.(Resource)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.DroppedAttributesCount != that1.DroppedAttributesCount {
+		return false
+	}
+	if len(this.EntityRefs) != len(that1.EntityRefs) {
+		return false
+	}
+	for i := range this.EntityRefs {
+		if !this.EntityRefs[i].Equal(that1.EntityRefs[i]) {
+			return false
+		}
+	}
+	return true
 }

--- a/gen/otlp/trace/v1/trace.go
+++ b/gen/otlp/trace/v1/trace.go
@@ -4,6 +4,7 @@
 package tracev1
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -12,88 +13,302 @@ import (
 	"wiresmith/gen/protohelpers"
 )
 
+// SpanFlags represents constants used to interpret the
+// Span.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
+//
+// (span.flags & SPAN_FLAGS_TRACE_FLAGS_MASK)
+//
+// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+//
+// Note that Span flags were introduced in version 1.1 of the
+// OpenTelemetry protocol.  Older Span producers do not set this
+// field, consequently consumers should not rely on the absence of a
+// particular flag bit to indicate the presence of a particular feature.
 type SpanFlags int32
 
 const (
-	SPAN_FLAGS_DO_NOT_USE                 SpanFlags = 0
-	SPAN_FLAGS_TRACE_FLAGS_MASK           SpanFlags = 255
+	// The zero value for the enum. Should not be used for comparisons.
+	// Instead use bitwise "and" with the appropriate mask as shown above.
+	SPAN_FLAGS_DO_NOT_USE SpanFlags = 0
+	// Bits 0-7 are used for trace flags.
+	SPAN_FLAGS_TRACE_FLAGS_MASK SpanFlags = 255
+	// Bits 8 and 9 are used to indicate that the parent span or link span is remote.
+	// Bit 8 (`HAS_IS_REMOTE`) indicates whether the value is known.
+	// Bit 9 (`IS_REMOTE`) indicates whether the span or link is remote.
 	SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK SpanFlags = 256
 	SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK     SpanFlags = 512
 )
 
+// SpanKind is the type of span. Can be used to specify additional relationships between spans
+// in addition to a parent/child relationship.
 type Span_SpanKind int32
 
 const (
+	// Unspecified. Do NOT use as default.
+	// Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED.
 	SPAN_KIND_UNSPECIFIED Span_SpanKind = 0
-	SPAN_KIND_INTERNAL    Span_SpanKind = 1
-	SPAN_KIND_SERVER      Span_SpanKind = 2
-	SPAN_KIND_CLIENT      Span_SpanKind = 3
-	SPAN_KIND_PRODUCER    Span_SpanKind = 4
-	SPAN_KIND_CONSUMER    Span_SpanKind = 5
+	// Indicates that the span represents an internal operation within an application,
+	// as opposed to an operation happening at the boundaries. Default value.
+	SPAN_KIND_INTERNAL Span_SpanKind = 1
+	// Indicates that the span covers server-side handling of an RPC or other
+	// remote network request.
+	SPAN_KIND_SERVER Span_SpanKind = 2
+	// Indicates that the span describes a request to some remote service.
+	SPAN_KIND_CLIENT Span_SpanKind = 3
+	// Indicates that the span describes a producer sending a message to a broker.
+	// Unlike CLIENT and SERVER, there is often no direct critical path latency relationship
+	// between producer and consumer spans. A PRODUCER span ends when the message was accepted
+	// by the broker while the logical processing of the message might span a much longer time.
+	SPAN_KIND_PRODUCER Span_SpanKind = 4
+	// Indicates that the span describes consumer receiving a message from a broker.
+	// Like the PRODUCER kind, there is often no direct critical path latency relationship
+	// between producer and consumer spans.
+	SPAN_KIND_CONSUMER Span_SpanKind = 5
 )
 
+// For the semantics of status codes see
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
 type Status_StatusCode int32
 
 const (
+	// The default status.
 	STATUS_CODE_UNSET Status_StatusCode = 0
-	STATUS_CODE_OK    Status_StatusCode = 1
+	// The Span has been validated by an Application developer or Operator to
+	// have completed successfully.
+	STATUS_CODE_OK Status_StatusCode = 1
+	// The Span contains an error.
 	STATUS_CODE_ERROR Status_StatusCode = 2
 )
 
+// TracesData represents the traces data that can be stored in a persistent storage,
+// OR can be embedded by other protocols that transfer OTLP traces data but do
+// not implement the OTLP protocol.
+//
+// The main difference between this message and collector protocol is that
+// in this message there will not be any "control" or "metadata" specific to
+// OTLP protocol.
+//
+// When new fields are added into this message, the OTLP request MUST be updated
+// as well.
 type TracesData struct {
+	// An array of ResourceSpans.
+	// For data coming from a single resource this array will typically contain
+	// one element. Intermediary nodes that receive data from multiple origins
+	// typically batch the data before forwarding further and in that case this
+	// array will contain multiple elements.
 	ResourceSpans []ResourceSpans
 }
 
+// A collection of ScopeSpans from a Resource.
 type ResourceSpans struct {
-	Resource   resourcev1.Resource
+	// The resource for the spans in this message.
+	// If this field is not set then no resource info is known.
+	Resource resourcev1.Resource
+	// A list of ScopeSpans that originate from a resource.
 	ScopeSpans []ScopeSpans
-	SchemaUrl  string
-}
-
-type ScopeSpans struct {
-	Scope     commonv1.InstrumentationScope
-	Spans     []Span
+	// The Schema URL, if known. This is the identifier of the Schema that the resource data
+	// is recorded in. Notably, the last part of the URL path is the version number of the
+	// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	// This schema_url applies to the data in the "resource" field. It does not apply
+	// to the data in the "scope_spans" field which have their own schema_url field.
 	SchemaUrl string
 }
 
+// A collection of Spans produced by an InstrumentationScope.
+type ScopeSpans struct {
+	// The instrumentation scope information for the spans in this message.
+	// Semantically when InstrumentationScope isn't set, it is equivalent with
+	// an empty instrumentation scope name (unknown).
+	Scope commonv1.InstrumentationScope
+	// A list of Spans that originate from an instrumentation scope.
+	Spans []Span
+	// The Schema URL, if known. This is the identifier of the Schema that the span data
+	// is recorded in. Notably, the last part of the URL path is the version number of the
+	// schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
+	// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+	// This schema_url applies to the data in the "scope" field and all spans and span
+	// events in the "spans" field.
+	SchemaUrl string
+}
+
+// Event is a time-stamped annotation of the span, consisting of user-supplied
+// text description and key-value pairs.
 type Span_Event struct {
-	TimeUnixNano           uint64
-	Name                   string
-	Attributes             []commonv1.KeyValue
+	// The time the event occurred.
+	TimeUnixNano uint64
+	// The name of the event.
+	// This field is semantically required to be set to non-empty string.
+	Name string
+	// A collection of attribute key/value pairs on the event.
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Attributes []commonv1.KeyValue
+	// The number of dropped attributes. If the value is 0,
+	// then no attributes were dropped.
 	DroppedAttributesCount uint32
 }
 
+// A pointer from the current span to another span in the same trace or in a
+// different trace. For example, this can be used in batching operations,
+// where a single batch handler processes multiple requests from different
+// traces or when the handler receives a request from a different project.
 type Span_Link struct {
-	TraceId                []byte
-	SpanId                 []byte
-	TraceState             string
-	Attributes             []commonv1.KeyValue
+	// A unique identifier of a trace that this linked span is part of. The ID is a
+	// 16-byte array.
+	TraceId []byte
+	// A unique identifier for the linked span. The ID is an 8-byte array.
+	SpanId []byte
+	// The trace_state associated with the link.
+	TraceState string
+	// A collection of attribute key/value pairs on the link.
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Attributes []commonv1.KeyValue
+	// The number of dropped attributes. If the value is 0,
+	// then no attributes were dropped.
 	DroppedAttributesCount uint32
-	Flags                  uint32
+	// Flags, a bit field.
+	//
+	// Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+	// Context specification. To read the 8-bit W3C trace flag, use
+	// `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+	//
+	// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+	//
+	// Bits 8 and 9 represent the 3 states of whether the link is remote.
+	// The states are (unknown, is not remote, is remote).
+	// To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`.
+	// To read whether the link is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`.
+	//
+	// Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
+	// When creating new spans, bits 10-31 (most-significant 22-bits) MUST be zero.
+	//
+	// [Optional].
+	Flags uint32
 }
 
+// A Span represents a single operation performed by a single component of the system.
+//
+// The next available field id is 17.
 type Span struct {
-	TraceId                []byte
-	SpanId                 []byte
-	TraceState             string
-	ParentSpanId           []byte
-	Flags                  uint32
-	Name                   string
-	Kind                   Span_SpanKind
-	StartTimeUnixNano      uint64
-	EndTimeUnixNano        uint64
-	Attributes             []commonv1.KeyValue
+	// A unique identifier for a trace. All spans from the same trace share
+	// the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
+	// of length other than 16 bytes is considered invalid (empty string in OTLP/JSON
+	// is zero-length and thus is also invalid).
+	//
+	// This field is required.
+	TraceId []byte
+	// A unique identifier for a span within a trace, assigned when the span
+	// is created. The ID is an 8-byte array. An ID with all zeroes OR of length
+	// other than 8 bytes is considered invalid (empty string in OTLP/JSON
+	// is zero-length and thus is also invalid).
+	//
+	// This field is required.
+	SpanId []byte
+	// trace_state conveys information about request position in multiple distributed tracing graphs.
+	// It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
+	// See also https://github.com/w3c/distributed-tracing for more details about this field.
+	TraceState string
+	// The `span_id` of this span's parent span. If this is a root span, then this
+	// field must be empty. The ID is an 8-byte array.
+	ParentSpanId []byte
+	// Flags, a bit field.
+	//
+	// Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+	// Context specification. To read the 8-bit W3C trace flag, use
+	// `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+	//
+	// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+	//
+	// Bits 8 and 9 represent the 3 states of whether a span's parent
+	// is remote. The states are (unknown, is not remote, is remote).
+	// To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`.
+	// To read whether the span is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`.
+	//
+	// When creating span messages, if the message is logically forwarded from another source
+	// with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
+	// be copied as-is. If creating from a source that does not have an equivalent flags field
+	// (such as a runtime representation of an OpenTelemetry span), the high 22 bits MUST
+	// be set to zero.
+	// Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
+	//
+	// [Optional].
+	Flags uint32
+	// A description of the span's operation.
+	//
+	// For example, the name can be a qualified method name or a file name
+	// and a line number where the operation is called. A best practice is to use
+	// the same display name at the same call point in an application.
+	// This makes it easier to correlate spans in different traces.
+	//
+	// This field is semantically required to be set to non-empty string.
+	// Empty value is equivalent to an unknown span name.
+	//
+	// This field is required.
+	Name string
+	// Distinguishes between spans generated in a particular context. For example,
+	// two spans with the same name may be distinguished using `CLIENT` (caller)
+	// and `SERVER` (callee) to identify queueing latency associated with the span.
+	Kind Span_SpanKind
+	// The start time of the span. On the client side, this is the time
+	// kept by the local machine where the span execution starts. On the server side, this
+	// is the time when the server's application handler starts running.
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+	//
+	// This field is semantically required and it is expected that end_time >= start_time.
+	StartTimeUnixNano uint64
+	// The end time of the span. On the client side, this is the time
+	// kept by the local machine where the span execution ends. On the server side, this
+	// is the time when the server application handler stops running.
+	// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+	//
+	// This field is semantically required and it is expected that end_time >= start_time.
+	EndTimeUnixNano uint64
+	// A collection of key/value pairs. Note, global attributes
+	// like server name can be set using the resource API. Examples of attributes:
+	//
+	// "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
+	// "/http/server_latency": 300
+	// "example.com/myattribute": true
+	// "example.com/score": 10.239
+	//
+	// Attribute keys MUST be unique (it is not allowed to have more than one
+	// attribute with the same key).
+	// The behavior of software that receives duplicated keys can be unpredictable.
+	Attributes []commonv1.KeyValue
+	// The number of attributes that were discarded. Attributes
+	// can be discarded because their keys are too long or because there are too many
+	// attributes. If this value is 0, then no attributes were dropped.
 	DroppedAttributesCount uint32
-	Events                 []Span_Event
-	DroppedEventsCount     uint32
-	Links                  []Span_Link
-	DroppedLinksCount      uint32
-	Status                 Status
+	// A collection of Event items.
+	Events []Span_Event
+	// The number of dropped events. If the value is 0, then no
+	// events were dropped.
+	DroppedEventsCount uint32
+	// A collection of Links, which are references from this span to a span
+	// in the same or different trace.
+	Links []Span_Link
+	// The number of dropped links after the maximum size was
+	// enforced. If this value is 0, then no links were dropped.
+	DroppedLinksCount uint32
+	// An optional final status for this span. Semantically when Status isn't set, it means
+	// span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
+	Status Status
 }
 
+// The Status type defines a logical error model that is suitable for different
+// programming environments, including REST APIs and RPC APIs.
 type Status struct {
+	// A developer-facing human readable error message.
 	Message string
-	Code    Status_StatusCode
+	// The status code.
+	Code Status_StatusCode
 }
 
 func (m *TracesData) Size() int {
@@ -255,10 +470,10 @@ func (m *Status) Size() int {
 
 func (m *TracesData) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -288,10 +503,10 @@ func (m *TracesData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ResourceSpans) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -340,10 +555,10 @@ func (m *ResourceSpans) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ScopeSpans) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -392,10 +607,10 @@ func (m *ScopeSpans) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Span_Event) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -443,10 +658,10 @@ func (m *Span_Event) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Span_Link) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -508,10 +723,10 @@ func (m *Span_Link) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Span) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -648,10 +863,10 @@ func (m *Span) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Status) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1675,4 +1890,303 @@ func (m *Status) unmarshal(b []byte, depth int) error {
 		}
 	}
 	return nil
+}
+
+func (this *TracesData) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*TracesData)
+	if !ok {
+		that2, ok := that.(TracesData)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.ResourceSpans) != len(that1.ResourceSpans) {
+		return false
+	}
+	for i := range this.ResourceSpans {
+		if !this.ResourceSpans[i].Equal(that1.ResourceSpans[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *ResourceSpans) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ResourceSpans)
+	if !ok {
+		that2, ok := that.(ResourceSpans)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Resource.Equal(that1.Resource) {
+		return false
+	}
+	if len(this.ScopeSpans) != len(that1.ScopeSpans) {
+		return false
+	}
+	for i := range this.ScopeSpans {
+		if !this.ScopeSpans[i].Equal(that1.ScopeSpans[i]) {
+			return false
+		}
+	}
+	if this.SchemaUrl != that1.SchemaUrl {
+		return false
+	}
+	return true
+}
+
+func (this *ScopeSpans) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ScopeSpans)
+	if !ok {
+		that2, ok := that.(ScopeSpans)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Scope.Equal(that1.Scope) {
+		return false
+	}
+	if len(this.Spans) != len(that1.Spans) {
+		return false
+	}
+	for i := range this.Spans {
+		if !this.Spans[i].Equal(that1.Spans[i]) {
+			return false
+		}
+	}
+	if this.SchemaUrl != that1.SchemaUrl {
+		return false
+	}
+	return true
+}
+
+func (this *Span_Event) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Span_Event)
+	if !ok {
+		that2, ok := that.(Span_Event)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.TimeUnixNano != that1.TimeUnixNano {
+		return false
+	}
+	if this.Name != that1.Name {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.DroppedAttributesCount != that1.DroppedAttributesCount {
+		return false
+	}
+	return true
+}
+
+func (this *Span_Link) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Span_Link)
+	if !ok {
+		that2, ok := that.(Span_Link)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !bytes.Equal(this.TraceId, that1.TraceId) {
+		return false
+	}
+	if !bytes.Equal(this.SpanId, that1.SpanId) {
+		return false
+	}
+	if this.TraceState != that1.TraceState {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.DroppedAttributesCount != that1.DroppedAttributesCount {
+		return false
+	}
+	if this.Flags != that1.Flags {
+		return false
+	}
+	return true
+}
+
+func (this *Span) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Span)
+	if !ok {
+		that2, ok := that.(Span)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !bytes.Equal(this.TraceId, that1.TraceId) {
+		return false
+	}
+	if !bytes.Equal(this.SpanId, that1.SpanId) {
+		return false
+	}
+	if this.TraceState != that1.TraceState {
+		return false
+	}
+	if !bytes.Equal(this.ParentSpanId, that1.ParentSpanId) {
+		return false
+	}
+	if this.Flags != that1.Flags {
+		return false
+	}
+	if this.Name != that1.Name {
+		return false
+	}
+	if this.Kind != that1.Kind {
+		return false
+	}
+	if this.StartTimeUnixNano != that1.StartTimeUnixNano {
+		return false
+	}
+	if this.EndTimeUnixNano != that1.EndTimeUnixNano {
+		return false
+	}
+	if len(this.Attributes) != len(that1.Attributes) {
+		return false
+	}
+	for i := range this.Attributes {
+		if !this.Attributes[i].Equal(that1.Attributes[i]) {
+			return false
+		}
+	}
+	if this.DroppedAttributesCount != that1.DroppedAttributesCount {
+		return false
+	}
+	if len(this.Events) != len(that1.Events) {
+		return false
+	}
+	for i := range this.Events {
+		if !this.Events[i].Equal(that1.Events[i]) {
+			return false
+		}
+	}
+	if this.DroppedEventsCount != that1.DroppedEventsCount {
+		return false
+	}
+	if len(this.Links) != len(that1.Links) {
+		return false
+	}
+	for i := range this.Links {
+		if !this.Links[i].Equal(that1.Links[i]) {
+			return false
+		}
+	}
+	if this.DroppedLinksCount != that1.DroppedLinksCount {
+		return false
+	}
+	if !this.Status.Equal(that1.Status) {
+		return false
+	}
+	return true
+}
+
+func (this *Status) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Status)
+	if !ok {
+		that2, ok := that.(Status)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Message != that1.Message {
+		return false
+	}
+	if this.Code != that1.Code {
+		return false
+	}
+	return true
 }

--- a/gen/protobuf_test_messages/proto3/test_messages_proto3.go
+++ b/gen/protobuf_test_messages/proto3/test_messages_proto3.go
@@ -6729,8 +6729,86 @@ func (this *TestAllTypesProto3) Equal(that interface{}) bool {
 			return false
 		}
 	}
-	if this.OneofField != that1.OneofField {
+	if (this.OneofField == nil) != (that1.OneofField == nil) {
 		return false
+	}
+	if this.OneofField != nil {
+		switch v := this.OneofField.(type) {
+		case *TestAllTypesProto3_OneofUint32:
+			v2, ok := that1.OneofField.(*TestAllTypesProto3_OneofUint32)
+			if !ok {
+				return false
+			}
+			if v.OneofUint32 != v2.OneofUint32 {
+				return false
+			}
+		case *TestAllTypesProto3_OneofNestedMessage:
+			v2, ok := that1.OneofField.(*TestAllTypesProto3_OneofNestedMessage)
+			if !ok {
+				return false
+			}
+			if !v.OneofNestedMessage.Equal(v2.OneofNestedMessage) {
+				return false
+			}
+		case *TestAllTypesProto3_OneofString:
+			v2, ok := that1.OneofField.(*TestAllTypesProto3_OneofString)
+			if !ok {
+				return false
+			}
+			if v.OneofString != v2.OneofString {
+				return false
+			}
+		case *TestAllTypesProto3_OneofBytes:
+			v2, ok := that1.OneofField.(*TestAllTypesProto3_OneofBytes)
+			if !ok {
+				return false
+			}
+			if !bytes.Equal(v.OneofBytes, v2.OneofBytes) {
+				return false
+			}
+		case *TestAllTypesProto3_OneofBool:
+			v2, ok := that1.OneofField.(*TestAllTypesProto3_OneofBool)
+			if !ok {
+				return false
+			}
+			if v.OneofBool != v2.OneofBool {
+				return false
+			}
+		case *TestAllTypesProto3_OneofUint64:
+			v2, ok := that1.OneofField.(*TestAllTypesProto3_OneofUint64)
+			if !ok {
+				return false
+			}
+			if v.OneofUint64 != v2.OneofUint64 {
+				return false
+			}
+		case *TestAllTypesProto3_OneofFloat:
+			v2, ok := that1.OneofField.(*TestAllTypesProto3_OneofFloat)
+			if !ok {
+				return false
+			}
+			if v.OneofFloat != v2.OneofFloat {
+				return false
+			}
+		case *TestAllTypesProto3_OneofDouble:
+			v2, ok := that1.OneofField.(*TestAllTypesProto3_OneofDouble)
+			if !ok {
+				return false
+			}
+			if v.OneofDouble != v2.OneofDouble {
+				return false
+			}
+		case *TestAllTypesProto3_OneofEnum:
+			v2, ok := that1.OneofField.(*TestAllTypesProto3_OneofEnum)
+			if !ok {
+				return false
+			}
+			if v.OneofEnum != v2.OneofEnum {
+				return false
+			}
+		default:
+			return false
+		}
 	}
 	if this.Fieldname1 != that1.Fieldname1 {
 		return false

--- a/gen/protobuf_test_messages/proto3/test_messages_proto3.go
+++ b/gen/protobuf_test_messages/proto3/test_messages_proto3.go
@@ -4,6 +4,7 @@
 package protobuf_test_messagesproto3
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -99,48 +100,54 @@ type TestAllTypesProto3_NestedMessage struct {
 }
 
 type TestAllTypesProto3 struct {
-	OptionalInt32           int32
-	OptionalInt64           int64
-	OptionalUint32          uint32
-	OptionalUint64          uint64
-	OptionalSint32          int32
-	OptionalSint64          int64
-	OptionalFixed32         uint32
-	OptionalFixed64         uint64
-	OptionalSfixed32        int32
-	OptionalSfixed64        int64
-	OptionalFloat           float32
-	OptionalDouble          float64
-	OptionalBool            bool
-	OptionalString          string
-	OptionalBytes           []byte
-	OptionalNestedMessage   TestAllTypesProto3_NestedMessage
-	OptionalForeignMessage  ForeignMessage
-	OptionalNestedEnum      TestAllTypesProto3_NestedEnum
-	OptionalForeignEnum     ForeignEnum
-	OptionalStringPiece     string
-	OptionalCord            string
-	RepeatedInt32           []int32
-	RepeatedInt64           []int64
-	RepeatedUint32          []uint32
-	RepeatedUint64          []uint64
-	RepeatedSint32          []int32
-	RepeatedSint64          []int64
-	RepeatedFixed32         []uint32
-	RepeatedFixed64         []uint64
-	RepeatedSfixed32        []int32
-	RepeatedSfixed64        []int64
-	RepeatedFloat           []float32
-	RepeatedDouble          []float64
-	RepeatedBool            []bool
-	RepeatedString          []string
-	RepeatedBytes           [][]byte
-	RepeatedNestedMessage   []TestAllTypesProto3_NestedMessage
-	RepeatedForeignMessage  []ForeignMessage
-	RepeatedNestedEnum      []TestAllTypesProto3_NestedEnum
-	RepeatedForeignEnum     []ForeignEnum
-	RepeatedStringPiece     []string
-	RepeatedCord            []string
+	// Singular fields — all supported scalar types.
+	OptionalInt32    int32
+	OptionalInt64    int64
+	OptionalUint32   uint32
+	OptionalUint64   uint64
+	OptionalSint32   int32
+	OptionalSint64   int64
+	OptionalFixed32  uint32
+	OptionalFixed64  uint64
+	OptionalSfixed32 int32
+	OptionalSfixed64 int64
+	OptionalFloat    float32
+	OptionalDouble   float64
+	OptionalBool     bool
+	OptionalString   string
+	OptionalBytes    []byte
+	// Singular message/enum fields.
+	OptionalNestedMessage  TestAllTypesProto3_NestedMessage
+	OptionalForeignMessage ForeignMessage
+	OptionalNestedEnum     TestAllTypesProto3_NestedEnum
+	OptionalForeignEnum    ForeignEnum
+	// field 23 (optional_aliased_enum) removed — allow_alias untested
+	OptionalStringPiece string
+	OptionalCord        string
+	// Repeated scalar fields.
+	RepeatedInt32    []int32
+	RepeatedInt64    []int64
+	RepeatedUint32   []uint32
+	RepeatedUint64   []uint64
+	RepeatedSint32   []int32
+	RepeatedSint64   []int64
+	RepeatedFixed32  []uint32
+	RepeatedFixed64  []uint64
+	RepeatedSfixed32 []int32
+	RepeatedSfixed64 []int64
+	RepeatedFloat    []float32
+	RepeatedDouble   []float64
+	RepeatedBool     []bool
+	RepeatedString   []string
+	RepeatedBytes    [][]byte
+	// Repeated message/enum fields.
+	RepeatedNestedMessage  []TestAllTypesProto3_NestedMessage
+	RepeatedForeignMessage []ForeignMessage
+	RepeatedNestedEnum     []TestAllTypesProto3_NestedEnum
+	RepeatedForeignEnum    []ForeignEnum
+	RepeatedStringPiece    []string
+	RepeatedCord           []string
+	// Map fields.
 	MapInt32Int32           map[int32]int32
 	MapInt64Int64           map[int64]int64
 	MapUint32Uint32         map[uint32]uint32
@@ -160,59 +167,64 @@ type TestAllTypesProto3 struct {
 	MapStringForeignMessage map[string]ForeignMessage
 	MapStringNestedEnum     map[string]TestAllTypesProto3_NestedEnum
 	MapStringForeignEnum    map[string]ForeignEnum
-	PackedInt32             []int32
-	PackedInt64             []int64
-	PackedUint32            []uint32
-	PackedUint64            []uint64
-	PackedSint32            []int32
-	PackedSint64            []int64
-	PackedFixed32           []uint32
-	PackedFixed64           []uint64
-	PackedSfixed32          []int32
-	PackedSfixed64          []int64
-	PackedFloat             []float32
-	PackedDouble            []float64
-	PackedBool              []bool
-	PackedNestedEnum        []TestAllTypesProto3_NestedEnum
-	UnpackedInt32           []int32
-	UnpackedInt64           []int64
-	UnpackedUint32          []uint32
-	UnpackedUint64          []uint64
-	UnpackedSint32          []int32
-	UnpackedSint64          []int64
-	UnpackedFixed32         []uint32
-	UnpackedFixed64         []uint64
-	UnpackedSfixed32        []int32
-	UnpackedSfixed64        []int64
-	UnpackedFloat           []float32
-	UnpackedDouble          []float64
-	UnpackedBool            []bool
-	UnpackedNestedEnum      []TestAllTypesProto3_NestedEnum
-	OneofField              TestAllTypesProto3_OneofField
-	Fieldname1              int32
-	FieldName2              int32
-	FieldName3              int32
-	FieldName4              int32
-	Field0name5             int32
-	Field0Name6             int32
-	FieldName7              int32
-	FieldName8              int32
-	FieldName9              int32
-	FieldName10             int32
-	FIELDNAME11             int32
-	FIELDName12             int32
-	FieldName13             int32
-	FieldName14             int32
-	FieldName15             int32
-	FieldName16             int32
-	FieldName17             int32
-	FieldName18             int32
+	// Packed repeated fields (explicit packed = true).
+	PackedInt32      []int32
+	PackedInt64      []int64
+	PackedUint32     []uint32
+	PackedUint64     []uint64
+	PackedSint32     []int32
+	PackedSint64     []int64
+	PackedFixed32    []uint32
+	PackedFixed64    []uint64
+	PackedSfixed32   []int32
+	PackedSfixed64   []int64
+	PackedFloat      []float32
+	PackedDouble     []float64
+	PackedBool       []bool
+	PackedNestedEnum []TestAllTypesProto3_NestedEnum
+	// Unpacked repeated fields (explicit packed = false).
+	UnpackedInt32      []int32
+	UnpackedInt64      []int64
+	UnpackedUint32     []uint32
+	UnpackedUint64     []uint64
+	UnpackedSint32     []int32
+	UnpackedSint64     []int64
+	UnpackedFixed32    []uint32
+	UnpackedFixed64    []uint64
+	UnpackedSfixed32   []int32
+	UnpackedSfixed64   []int64
+	UnpackedFloat      []float32
+	UnpackedDouble     []float64
+	UnpackedBool       []bool
+	UnpackedNestedEnum []TestAllTypesProto3_NestedEnum
+	// Oneof field — supported variants only.
+	OneofField TestAllTypesProto3_OneofField
+	// Field name convention tests — all int32, exercising name mangling.
+	Fieldname1  int32
+	FieldName2  int32
+	FieldName3  int32
+	FieldName4  int32
+	Field0name5 int32
+	Field0Name6 int32
+	FieldName7  int32
+	FieldName8  int32
+	FieldName9  int32
+	FieldName10 int32
+	FIELDNAME11 int32
+	FIELDName12 int32
+	FieldName13 int32
+	FieldName14 int32
+	FieldName15 int32
+	FieldName16 int32
+	FieldName17 int32
+	FieldName18 int32
 }
 
 type ForeignMessage struct {
 	C int32
 }
 
+// Empty message used in conformance tests.
 type NullHypothesisProto3 struct {
 }
 
@@ -726,10 +738,10 @@ func (m *EnumOnlyProto3) Size() int {
 
 func (m *TestAllTypesProto3_NestedMessage) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -754,10 +766,10 @@ func (m *TestAllTypesProto3_NestedMessage) MarshalToSizedBuffer(dAtA []byte) (in
 
 func (m *TestAllTypesProto3) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1952,10 +1964,10 @@ func (m *TestAllTypesProto3) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *ForeignMessage) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1980,10 +1992,10 @@ func (m *ForeignMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *NullHypothesisProto3) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -2003,10 +2015,10 @@ func (m *NullHypothesisProto3) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *EnumOnlyProto3) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -5988,4 +6000,860 @@ func (m *EnumOnlyProto3) unmarshal(b []byte, depth int) error {
 		}
 	}
 	return nil
+}
+
+func (this *TestAllTypesProto3_NestedMessage) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*TestAllTypesProto3_NestedMessage)
+	if !ok {
+		that2, ok := that.(TestAllTypesProto3_NestedMessage)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.A != that1.A {
+		return false
+	}
+	return true
+}
+
+func (this *TestAllTypesProto3) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*TestAllTypesProto3)
+	if !ok {
+		that2, ok := that.(TestAllTypesProto3)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.OptionalInt32 != that1.OptionalInt32 {
+		return false
+	}
+	if this.OptionalInt64 != that1.OptionalInt64 {
+		return false
+	}
+	if this.OptionalUint32 != that1.OptionalUint32 {
+		return false
+	}
+	if this.OptionalUint64 != that1.OptionalUint64 {
+		return false
+	}
+	if this.OptionalSint32 != that1.OptionalSint32 {
+		return false
+	}
+	if this.OptionalSint64 != that1.OptionalSint64 {
+		return false
+	}
+	if this.OptionalFixed32 != that1.OptionalFixed32 {
+		return false
+	}
+	if this.OptionalFixed64 != that1.OptionalFixed64 {
+		return false
+	}
+	if this.OptionalSfixed32 != that1.OptionalSfixed32 {
+		return false
+	}
+	if this.OptionalSfixed64 != that1.OptionalSfixed64 {
+		return false
+	}
+	if this.OptionalFloat != that1.OptionalFloat {
+		return false
+	}
+	if this.OptionalDouble != that1.OptionalDouble {
+		return false
+	}
+	if this.OptionalBool != that1.OptionalBool {
+		return false
+	}
+	if this.OptionalString != that1.OptionalString {
+		return false
+	}
+	if !bytes.Equal(this.OptionalBytes, that1.OptionalBytes) {
+		return false
+	}
+	if !this.OptionalNestedMessage.Equal(that1.OptionalNestedMessage) {
+		return false
+	}
+	if !this.OptionalForeignMessage.Equal(that1.OptionalForeignMessage) {
+		return false
+	}
+	if this.OptionalNestedEnum != that1.OptionalNestedEnum {
+		return false
+	}
+	if this.OptionalForeignEnum != that1.OptionalForeignEnum {
+		return false
+	}
+	if this.OptionalStringPiece != that1.OptionalStringPiece {
+		return false
+	}
+	if this.OptionalCord != that1.OptionalCord {
+		return false
+	}
+	if len(this.RepeatedInt32) != len(that1.RepeatedInt32) {
+		return false
+	}
+	for i := range this.RepeatedInt32 {
+		if this.RepeatedInt32[i] != that1.RepeatedInt32[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedInt64) != len(that1.RepeatedInt64) {
+		return false
+	}
+	for i := range this.RepeatedInt64 {
+		if this.RepeatedInt64[i] != that1.RepeatedInt64[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedUint32) != len(that1.RepeatedUint32) {
+		return false
+	}
+	for i := range this.RepeatedUint32 {
+		if this.RepeatedUint32[i] != that1.RepeatedUint32[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedUint64) != len(that1.RepeatedUint64) {
+		return false
+	}
+	for i := range this.RepeatedUint64 {
+		if this.RepeatedUint64[i] != that1.RepeatedUint64[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedSint32) != len(that1.RepeatedSint32) {
+		return false
+	}
+	for i := range this.RepeatedSint32 {
+		if this.RepeatedSint32[i] != that1.RepeatedSint32[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedSint64) != len(that1.RepeatedSint64) {
+		return false
+	}
+	for i := range this.RepeatedSint64 {
+		if this.RepeatedSint64[i] != that1.RepeatedSint64[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedFixed32) != len(that1.RepeatedFixed32) {
+		return false
+	}
+	for i := range this.RepeatedFixed32 {
+		if this.RepeatedFixed32[i] != that1.RepeatedFixed32[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedFixed64) != len(that1.RepeatedFixed64) {
+		return false
+	}
+	for i := range this.RepeatedFixed64 {
+		if this.RepeatedFixed64[i] != that1.RepeatedFixed64[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedSfixed32) != len(that1.RepeatedSfixed32) {
+		return false
+	}
+	for i := range this.RepeatedSfixed32 {
+		if this.RepeatedSfixed32[i] != that1.RepeatedSfixed32[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedSfixed64) != len(that1.RepeatedSfixed64) {
+		return false
+	}
+	for i := range this.RepeatedSfixed64 {
+		if this.RepeatedSfixed64[i] != that1.RepeatedSfixed64[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedFloat) != len(that1.RepeatedFloat) {
+		return false
+	}
+	for i := range this.RepeatedFloat {
+		if this.RepeatedFloat[i] != that1.RepeatedFloat[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedDouble) != len(that1.RepeatedDouble) {
+		return false
+	}
+	for i := range this.RepeatedDouble {
+		if this.RepeatedDouble[i] != that1.RepeatedDouble[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedBool) != len(that1.RepeatedBool) {
+		return false
+	}
+	for i := range this.RepeatedBool {
+		if this.RepeatedBool[i] != that1.RepeatedBool[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedString) != len(that1.RepeatedString) {
+		return false
+	}
+	for i := range this.RepeatedString {
+		if this.RepeatedString[i] != that1.RepeatedString[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedBytes) != len(that1.RepeatedBytes) {
+		return false
+	}
+	for i := range this.RepeatedBytes {
+		if !bytes.Equal(this.RepeatedBytes[i], that1.RepeatedBytes[i]) {
+			return false
+		}
+	}
+	if len(this.RepeatedNestedMessage) != len(that1.RepeatedNestedMessage) {
+		return false
+	}
+	for i := range this.RepeatedNestedMessage {
+		if !this.RepeatedNestedMessage[i].Equal(that1.RepeatedNestedMessage[i]) {
+			return false
+		}
+	}
+	if len(this.RepeatedForeignMessage) != len(that1.RepeatedForeignMessage) {
+		return false
+	}
+	for i := range this.RepeatedForeignMessage {
+		if !this.RepeatedForeignMessage[i].Equal(that1.RepeatedForeignMessage[i]) {
+			return false
+		}
+	}
+	if len(this.RepeatedNestedEnum) != len(that1.RepeatedNestedEnum) {
+		return false
+	}
+	for i := range this.RepeatedNestedEnum {
+		if this.RepeatedNestedEnum[i] != that1.RepeatedNestedEnum[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedForeignEnum) != len(that1.RepeatedForeignEnum) {
+		return false
+	}
+	for i := range this.RepeatedForeignEnum {
+		if this.RepeatedForeignEnum[i] != that1.RepeatedForeignEnum[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedStringPiece) != len(that1.RepeatedStringPiece) {
+		return false
+	}
+	for i := range this.RepeatedStringPiece {
+		if this.RepeatedStringPiece[i] != that1.RepeatedStringPiece[i] {
+			return false
+		}
+	}
+	if len(this.RepeatedCord) != len(that1.RepeatedCord) {
+		return false
+	}
+	for i := range this.RepeatedCord {
+		if this.RepeatedCord[i] != that1.RepeatedCord[i] {
+			return false
+		}
+	}
+	if len(this.MapInt32Int32) != len(that1.MapInt32Int32) {
+		return false
+	}
+	for k, v := range this.MapInt32Int32 {
+		v2, ok := that1.MapInt32Int32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapInt64Int64) != len(that1.MapInt64Int64) {
+		return false
+	}
+	for k, v := range this.MapInt64Int64 {
+		v2, ok := that1.MapInt64Int64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapUint32Uint32) != len(that1.MapUint32Uint32) {
+		return false
+	}
+	for k, v := range this.MapUint32Uint32 {
+		v2, ok := that1.MapUint32Uint32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapUint64Uint64) != len(that1.MapUint64Uint64) {
+		return false
+	}
+	for k, v := range this.MapUint64Uint64 {
+		v2, ok := that1.MapUint64Uint64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapSint32Sint32) != len(that1.MapSint32Sint32) {
+		return false
+	}
+	for k, v := range this.MapSint32Sint32 {
+		v2, ok := that1.MapSint32Sint32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapSint64Sint64) != len(that1.MapSint64Sint64) {
+		return false
+	}
+	for k, v := range this.MapSint64Sint64 {
+		v2, ok := that1.MapSint64Sint64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapFixed32Fixed32) != len(that1.MapFixed32Fixed32) {
+		return false
+	}
+	for k, v := range this.MapFixed32Fixed32 {
+		v2, ok := that1.MapFixed32Fixed32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapFixed64Fixed64) != len(that1.MapFixed64Fixed64) {
+		return false
+	}
+	for k, v := range this.MapFixed64Fixed64 {
+		v2, ok := that1.MapFixed64Fixed64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapSfixed32Sfixed32) != len(that1.MapSfixed32Sfixed32) {
+		return false
+	}
+	for k, v := range this.MapSfixed32Sfixed32 {
+		v2, ok := that1.MapSfixed32Sfixed32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapSfixed64Sfixed64) != len(that1.MapSfixed64Sfixed64) {
+		return false
+	}
+	for k, v := range this.MapSfixed64Sfixed64 {
+		v2, ok := that1.MapSfixed64Sfixed64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapInt32Float) != len(that1.MapInt32Float) {
+		return false
+	}
+	for k, v := range this.MapInt32Float {
+		v2, ok := that1.MapInt32Float[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapInt32Double) != len(that1.MapInt32Double) {
+		return false
+	}
+	for k, v := range this.MapInt32Double {
+		v2, ok := that1.MapInt32Double[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapBoolBool) != len(that1.MapBoolBool) {
+		return false
+	}
+	for k, v := range this.MapBoolBool {
+		v2, ok := that1.MapBoolBool[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapStringString) != len(that1.MapStringString) {
+		return false
+	}
+	for k, v := range this.MapStringString {
+		v2, ok := that1.MapStringString[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapStringBytes) != len(that1.MapStringBytes) {
+		return false
+	}
+	for k, v := range this.MapStringBytes {
+		v2, ok := that1.MapStringBytes[k]
+		if !ok {
+			return false
+		}
+		if !bytes.Equal(v, v2) {
+			return false
+		}
+	}
+	if len(this.MapStringNestedMessage) != len(that1.MapStringNestedMessage) {
+		return false
+	}
+	for k, v := range this.MapStringNestedMessage {
+		v2, ok := that1.MapStringNestedMessage[k]
+		if !ok {
+			return false
+		}
+		if !v.Equal(v2) {
+			return false
+		}
+	}
+	if len(this.MapStringForeignMessage) != len(that1.MapStringForeignMessage) {
+		return false
+	}
+	for k, v := range this.MapStringForeignMessage {
+		v2, ok := that1.MapStringForeignMessage[k]
+		if !ok {
+			return false
+		}
+		if !v.Equal(v2) {
+			return false
+		}
+	}
+	if len(this.MapStringNestedEnum) != len(that1.MapStringNestedEnum) {
+		return false
+	}
+	for k, v := range this.MapStringNestedEnum {
+		v2, ok := that1.MapStringNestedEnum[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapStringForeignEnum) != len(that1.MapStringForeignEnum) {
+		return false
+	}
+	for k, v := range this.MapStringForeignEnum {
+		v2, ok := that1.MapStringForeignEnum[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.PackedInt32) != len(that1.PackedInt32) {
+		return false
+	}
+	for i := range this.PackedInt32 {
+		if this.PackedInt32[i] != that1.PackedInt32[i] {
+			return false
+		}
+	}
+	if len(this.PackedInt64) != len(that1.PackedInt64) {
+		return false
+	}
+	for i := range this.PackedInt64 {
+		if this.PackedInt64[i] != that1.PackedInt64[i] {
+			return false
+		}
+	}
+	if len(this.PackedUint32) != len(that1.PackedUint32) {
+		return false
+	}
+	for i := range this.PackedUint32 {
+		if this.PackedUint32[i] != that1.PackedUint32[i] {
+			return false
+		}
+	}
+	if len(this.PackedUint64) != len(that1.PackedUint64) {
+		return false
+	}
+	for i := range this.PackedUint64 {
+		if this.PackedUint64[i] != that1.PackedUint64[i] {
+			return false
+		}
+	}
+	if len(this.PackedSint32) != len(that1.PackedSint32) {
+		return false
+	}
+	for i := range this.PackedSint32 {
+		if this.PackedSint32[i] != that1.PackedSint32[i] {
+			return false
+		}
+	}
+	if len(this.PackedSint64) != len(that1.PackedSint64) {
+		return false
+	}
+	for i := range this.PackedSint64 {
+		if this.PackedSint64[i] != that1.PackedSint64[i] {
+			return false
+		}
+	}
+	if len(this.PackedFixed32) != len(that1.PackedFixed32) {
+		return false
+	}
+	for i := range this.PackedFixed32 {
+		if this.PackedFixed32[i] != that1.PackedFixed32[i] {
+			return false
+		}
+	}
+	if len(this.PackedFixed64) != len(that1.PackedFixed64) {
+		return false
+	}
+	for i := range this.PackedFixed64 {
+		if this.PackedFixed64[i] != that1.PackedFixed64[i] {
+			return false
+		}
+	}
+	if len(this.PackedSfixed32) != len(that1.PackedSfixed32) {
+		return false
+	}
+	for i := range this.PackedSfixed32 {
+		if this.PackedSfixed32[i] != that1.PackedSfixed32[i] {
+			return false
+		}
+	}
+	if len(this.PackedSfixed64) != len(that1.PackedSfixed64) {
+		return false
+	}
+	for i := range this.PackedSfixed64 {
+		if this.PackedSfixed64[i] != that1.PackedSfixed64[i] {
+			return false
+		}
+	}
+	if len(this.PackedFloat) != len(that1.PackedFloat) {
+		return false
+	}
+	for i := range this.PackedFloat {
+		if this.PackedFloat[i] != that1.PackedFloat[i] {
+			return false
+		}
+	}
+	if len(this.PackedDouble) != len(that1.PackedDouble) {
+		return false
+	}
+	for i := range this.PackedDouble {
+		if this.PackedDouble[i] != that1.PackedDouble[i] {
+			return false
+		}
+	}
+	if len(this.PackedBool) != len(that1.PackedBool) {
+		return false
+	}
+	for i := range this.PackedBool {
+		if this.PackedBool[i] != that1.PackedBool[i] {
+			return false
+		}
+	}
+	if len(this.PackedNestedEnum) != len(that1.PackedNestedEnum) {
+		return false
+	}
+	for i := range this.PackedNestedEnum {
+		if this.PackedNestedEnum[i] != that1.PackedNestedEnum[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedInt32) != len(that1.UnpackedInt32) {
+		return false
+	}
+	for i := range this.UnpackedInt32 {
+		if this.UnpackedInt32[i] != that1.UnpackedInt32[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedInt64) != len(that1.UnpackedInt64) {
+		return false
+	}
+	for i := range this.UnpackedInt64 {
+		if this.UnpackedInt64[i] != that1.UnpackedInt64[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedUint32) != len(that1.UnpackedUint32) {
+		return false
+	}
+	for i := range this.UnpackedUint32 {
+		if this.UnpackedUint32[i] != that1.UnpackedUint32[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedUint64) != len(that1.UnpackedUint64) {
+		return false
+	}
+	for i := range this.UnpackedUint64 {
+		if this.UnpackedUint64[i] != that1.UnpackedUint64[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedSint32) != len(that1.UnpackedSint32) {
+		return false
+	}
+	for i := range this.UnpackedSint32 {
+		if this.UnpackedSint32[i] != that1.UnpackedSint32[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedSint64) != len(that1.UnpackedSint64) {
+		return false
+	}
+	for i := range this.UnpackedSint64 {
+		if this.UnpackedSint64[i] != that1.UnpackedSint64[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedFixed32) != len(that1.UnpackedFixed32) {
+		return false
+	}
+	for i := range this.UnpackedFixed32 {
+		if this.UnpackedFixed32[i] != that1.UnpackedFixed32[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedFixed64) != len(that1.UnpackedFixed64) {
+		return false
+	}
+	for i := range this.UnpackedFixed64 {
+		if this.UnpackedFixed64[i] != that1.UnpackedFixed64[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedSfixed32) != len(that1.UnpackedSfixed32) {
+		return false
+	}
+	for i := range this.UnpackedSfixed32 {
+		if this.UnpackedSfixed32[i] != that1.UnpackedSfixed32[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedSfixed64) != len(that1.UnpackedSfixed64) {
+		return false
+	}
+	for i := range this.UnpackedSfixed64 {
+		if this.UnpackedSfixed64[i] != that1.UnpackedSfixed64[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedFloat) != len(that1.UnpackedFloat) {
+		return false
+	}
+	for i := range this.UnpackedFloat {
+		if this.UnpackedFloat[i] != that1.UnpackedFloat[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedDouble) != len(that1.UnpackedDouble) {
+		return false
+	}
+	for i := range this.UnpackedDouble {
+		if this.UnpackedDouble[i] != that1.UnpackedDouble[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedBool) != len(that1.UnpackedBool) {
+		return false
+	}
+	for i := range this.UnpackedBool {
+		if this.UnpackedBool[i] != that1.UnpackedBool[i] {
+			return false
+		}
+	}
+	if len(this.UnpackedNestedEnum) != len(that1.UnpackedNestedEnum) {
+		return false
+	}
+	for i := range this.UnpackedNestedEnum {
+		if this.UnpackedNestedEnum[i] != that1.UnpackedNestedEnum[i] {
+			return false
+		}
+	}
+	if this.OneofField != that1.OneofField {
+		return false
+	}
+	if this.Fieldname1 != that1.Fieldname1 {
+		return false
+	}
+	if this.FieldName2 != that1.FieldName2 {
+		return false
+	}
+	if this.FieldName3 != that1.FieldName3 {
+		return false
+	}
+	if this.FieldName4 != that1.FieldName4 {
+		return false
+	}
+	if this.Field0name5 != that1.Field0name5 {
+		return false
+	}
+	if this.Field0Name6 != that1.Field0Name6 {
+		return false
+	}
+	if this.FieldName7 != that1.FieldName7 {
+		return false
+	}
+	if this.FieldName8 != that1.FieldName8 {
+		return false
+	}
+	if this.FieldName9 != that1.FieldName9 {
+		return false
+	}
+	if this.FieldName10 != that1.FieldName10 {
+		return false
+	}
+	if this.FIELDNAME11 != that1.FIELDNAME11 {
+		return false
+	}
+	if this.FIELDName12 != that1.FIELDName12 {
+		return false
+	}
+	if this.FieldName13 != that1.FieldName13 {
+		return false
+	}
+	if this.FieldName14 != that1.FieldName14 {
+		return false
+	}
+	if this.FieldName15 != that1.FieldName15 {
+		return false
+	}
+	if this.FieldName16 != that1.FieldName16 {
+		return false
+	}
+	if this.FieldName17 != that1.FieldName17 {
+		return false
+	}
+	if this.FieldName18 != that1.FieldName18 {
+		return false
+	}
+	return true
+}
+
+func (this *ForeignMessage) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*ForeignMessage)
+	if !ok {
+		that2, ok := that.(ForeignMessage)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.C != that1.C {
+		return false
+	}
+	return true
+}
+
+func (this *NullHypothesisProto3) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*NullHypothesisProto3)
+	if !ok {
+		that2, ok := that.(NullHypothesisProto3)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	return true
+}
+
+func (this *EnumOnlyProto3) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*EnumOnlyProto3)
+	if !ok {
+		that2, ok := that.(EnumOnlyProto3)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	return true
 }

--- a/gen/test/kitchensink/v1/kitchen_sink.go
+++ b/gen/test/kitchensink/v1/kitchen_sink.go
@@ -5463,6 +5463,9 @@ func (this *AllOptionalScalars) Equal(that interface{}) bool {
 			return false
 		}
 	}
+	if (this.FieldBytes == nil) != (that1.FieldBytes == nil) {
+		return false
+	}
 	if !bytes.Equal(this.FieldBytes, that1.FieldBytes) {
 		return false
 	}
@@ -5630,8 +5633,134 @@ func (this *OneofVariants) Equal(that interface{}) bool {
 	} else if this == nil {
 		return false
 	}
-	if this.Value != that1.Value {
+	if (this.Value == nil) != (that1.Value == nil) {
 		return false
+	}
+	if this.Value != nil {
+		switch v := this.Value.(type) {
+		case *OneofVariants_DoubleValue:
+			v2, ok := that1.Value.(*OneofVariants_DoubleValue)
+			if !ok {
+				return false
+			}
+			if v.DoubleValue != v2.DoubleValue {
+				return false
+			}
+		case *OneofVariants_FloatValue:
+			v2, ok := that1.Value.(*OneofVariants_FloatValue)
+			if !ok {
+				return false
+			}
+			if v.FloatValue != v2.FloatValue {
+				return false
+			}
+		case *OneofVariants_Int32Value:
+			v2, ok := that1.Value.(*OneofVariants_Int32Value)
+			if !ok {
+				return false
+			}
+			if v.Int32Value != v2.Int32Value {
+				return false
+			}
+		case *OneofVariants_Int64Value:
+			v2, ok := that1.Value.(*OneofVariants_Int64Value)
+			if !ok {
+				return false
+			}
+			if v.Int64Value != v2.Int64Value {
+				return false
+			}
+		case *OneofVariants_Uint32Value:
+			v2, ok := that1.Value.(*OneofVariants_Uint32Value)
+			if !ok {
+				return false
+			}
+			if v.Uint32Value != v2.Uint32Value {
+				return false
+			}
+		case *OneofVariants_Uint64Value:
+			v2, ok := that1.Value.(*OneofVariants_Uint64Value)
+			if !ok {
+				return false
+			}
+			if v.Uint64Value != v2.Uint64Value {
+				return false
+			}
+		case *OneofVariants_Sint32Value:
+			v2, ok := that1.Value.(*OneofVariants_Sint32Value)
+			if !ok {
+				return false
+			}
+			if v.Sint32Value != v2.Sint32Value {
+				return false
+			}
+		case *OneofVariants_Sint64Value:
+			v2, ok := that1.Value.(*OneofVariants_Sint64Value)
+			if !ok {
+				return false
+			}
+			if v.Sint64Value != v2.Sint64Value {
+				return false
+			}
+		case *OneofVariants_Fixed32Value:
+			v2, ok := that1.Value.(*OneofVariants_Fixed32Value)
+			if !ok {
+				return false
+			}
+			if v.Fixed32Value != v2.Fixed32Value {
+				return false
+			}
+		case *OneofVariants_Fixed64Value:
+			v2, ok := that1.Value.(*OneofVariants_Fixed64Value)
+			if !ok {
+				return false
+			}
+			if v.Fixed64Value != v2.Fixed64Value {
+				return false
+			}
+		case *OneofVariants_Sfixed32Value:
+			v2, ok := that1.Value.(*OneofVariants_Sfixed32Value)
+			if !ok {
+				return false
+			}
+			if v.Sfixed32Value != v2.Sfixed32Value {
+				return false
+			}
+		case *OneofVariants_Sfixed64Value:
+			v2, ok := that1.Value.(*OneofVariants_Sfixed64Value)
+			if !ok {
+				return false
+			}
+			if v.Sfixed64Value != v2.Sfixed64Value {
+				return false
+			}
+		case *OneofVariants_BoolValue:
+			v2, ok := that1.Value.(*OneofVariants_BoolValue)
+			if !ok {
+				return false
+			}
+			if v.BoolValue != v2.BoolValue {
+				return false
+			}
+		case *OneofVariants_StringValue:
+			v2, ok := that1.Value.(*OneofVariants_StringValue)
+			if !ok {
+				return false
+			}
+			if v.StringValue != v2.StringValue {
+				return false
+			}
+		case *OneofVariants_BytesValue:
+			v2, ok := that1.Value.(*OneofVariants_BytesValue)
+			if !ok {
+				return false
+			}
+			if !bytes.Equal(v.BytesValue, v2.BytesValue) {
+				return false
+			}
+		default:
+			return false
+		}
 	}
 	return true
 }

--- a/gen/test/kitchensink/v1/kitchen_sink.go
+++ b/gen/test/kitchensink/v1/kitchen_sink.go
@@ -4,6 +4,7 @@
 package kitchensinkv1
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -12,6 +13,7 @@ import (
 	"wiresmith/gen/protohelpers"
 )
 
+// Enum testing
 type Color int32
 
 const (
@@ -115,6 +117,7 @@ type OneofVariants_BytesValue struct {
 
 func (*OneofVariants_BytesValue) isOneofVariants_Value() {}
 
+// Message with every singular scalar type
 type AllScalars struct {
 	FieldDouble   float64
 	FieldFloat    float32
@@ -133,6 +136,7 @@ type AllScalars struct {
 	FieldBytes    []byte
 }
 
+// Message with every optional scalar type
 type AllOptionalScalars struct {
 	FieldDouble   *float64
 	FieldFloat    *float32
@@ -151,6 +155,7 @@ type AllOptionalScalars struct {
 	FieldBytes    []byte
 }
 
+// Message with every repeated (packed) scalar type
 type AllRepeatedScalars struct {
 	FieldDouble   []float64
 	FieldFloat    []float32
@@ -169,10 +174,12 @@ type AllRepeatedScalars struct {
 	FieldBytes    [][]byte
 }
 
+// Oneof with various types
 type OneofVariants struct {
 	Value OneofVariants_Value
 }
 
+// Nested messages for depth testing
 type Outer struct {
 	Middle  Middle
 	Middles []Middle
@@ -192,6 +199,7 @@ type Inner struct {
 	FixedVal  int32
 }
 
+// High field numbers (multi-byte tags)
 type HighFieldNumbers struct {
 	Field1     string
 	Field16    string
@@ -205,21 +213,25 @@ type WithEnum struct {
 	Colors []Color
 }
 
+// Empty message
 type Empty struct {
 }
 
+// Message with only repeated fields
 type OnlyRepeated struct {
 	Names  []string
 	Values []int64
 	Items  []Inner
 }
 
+// Message referencing another message with oneof
 type Container struct {
 	Variant  OneofVariants
 	Scalars  AllScalars
 	Variants []OneofVariants
 }
 
+// Maps with all supported key/value type combinations
 type AllMaps struct {
 	MapInt32Int32       map[int32]int32
 	MapInt64Int64       map[int64]int64
@@ -710,10 +722,10 @@ func (m *AllMaps) Size() int {
 
 func (m *AllScalars) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -823,10 +835,10 @@ func (m *AllScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *AllOptionalScalars) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -938,10 +950,10 @@ func (m *AllOptionalScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *AllRepeatedScalars) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1104,10 +1116,10 @@ func (m *AllRepeatedScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *OneofVariants) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1204,10 +1216,10 @@ func (m *OneofVariants) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Outer) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1256,10 +1268,10 @@ func (m *Outer) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Middle) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1306,10 +1318,10 @@ func (m *Middle) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Inner) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1354,10 +1366,10 @@ func (m *Inner) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *HighFieldNumbers) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1424,10 +1436,10 @@ func (m *HighFieldNumbers) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *WithEnum) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1462,10 +1474,10 @@ func (m *WithEnum) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Empty) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1485,10 +1497,10 @@ func (m *Empty) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *OnlyRepeated) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1535,10 +1547,10 @@ func (m *OnlyRepeated) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *Container) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -1592,10 +1604,10 @@ func (m *Container) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 
 func (m *AllMaps) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
-	if size == 0 {
-		return nil, nil
-	}
 	dAtA = make([]byte, size)
+	if size == 0 {
+		return dAtA, nil
+	}
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
@@ -5251,4 +5263,881 @@ func (m *AllMaps) unmarshal(b []byte, depth int) error {
 		}
 	}
 	return nil
+}
+
+func (this *AllScalars) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*AllScalars)
+	if !ok {
+		that2, ok := that.(AllScalars)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.FieldDouble != that1.FieldDouble {
+		return false
+	}
+	if this.FieldFloat != that1.FieldFloat {
+		return false
+	}
+	if this.FieldInt32 != that1.FieldInt32 {
+		return false
+	}
+	if this.FieldInt64 != that1.FieldInt64 {
+		return false
+	}
+	if this.FieldUint32 != that1.FieldUint32 {
+		return false
+	}
+	if this.FieldUint64 != that1.FieldUint64 {
+		return false
+	}
+	if this.FieldSint32 != that1.FieldSint32 {
+		return false
+	}
+	if this.FieldSint64 != that1.FieldSint64 {
+		return false
+	}
+	if this.FieldFixed32 != that1.FieldFixed32 {
+		return false
+	}
+	if this.FieldFixed64 != that1.FieldFixed64 {
+		return false
+	}
+	if this.FieldSfixed32 != that1.FieldSfixed32 {
+		return false
+	}
+	if this.FieldSfixed64 != that1.FieldSfixed64 {
+		return false
+	}
+	if this.FieldBool != that1.FieldBool {
+		return false
+	}
+	if this.FieldString != that1.FieldString {
+		return false
+	}
+	if !bytes.Equal(this.FieldBytes, that1.FieldBytes) {
+		return false
+	}
+	return true
+}
+
+func (this *AllOptionalScalars) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*AllOptionalScalars)
+	if !ok {
+		that2, ok := that.(AllOptionalScalars)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.FieldDouble != that1.FieldDouble {
+		if this.FieldDouble == nil || that1.FieldDouble == nil {
+			return false
+		}
+		if *this.FieldDouble != *that1.FieldDouble {
+			return false
+		}
+	}
+	if this.FieldFloat != that1.FieldFloat {
+		if this.FieldFloat == nil || that1.FieldFloat == nil {
+			return false
+		}
+		if *this.FieldFloat != *that1.FieldFloat {
+			return false
+		}
+	}
+	if this.FieldInt32 != that1.FieldInt32 {
+		if this.FieldInt32 == nil || that1.FieldInt32 == nil {
+			return false
+		}
+		if *this.FieldInt32 != *that1.FieldInt32 {
+			return false
+		}
+	}
+	if this.FieldInt64 != that1.FieldInt64 {
+		if this.FieldInt64 == nil || that1.FieldInt64 == nil {
+			return false
+		}
+		if *this.FieldInt64 != *that1.FieldInt64 {
+			return false
+		}
+	}
+	if this.FieldUint32 != that1.FieldUint32 {
+		if this.FieldUint32 == nil || that1.FieldUint32 == nil {
+			return false
+		}
+		if *this.FieldUint32 != *that1.FieldUint32 {
+			return false
+		}
+	}
+	if this.FieldUint64 != that1.FieldUint64 {
+		if this.FieldUint64 == nil || that1.FieldUint64 == nil {
+			return false
+		}
+		if *this.FieldUint64 != *that1.FieldUint64 {
+			return false
+		}
+	}
+	if this.FieldSint32 != that1.FieldSint32 {
+		if this.FieldSint32 == nil || that1.FieldSint32 == nil {
+			return false
+		}
+		if *this.FieldSint32 != *that1.FieldSint32 {
+			return false
+		}
+	}
+	if this.FieldSint64 != that1.FieldSint64 {
+		if this.FieldSint64 == nil || that1.FieldSint64 == nil {
+			return false
+		}
+		if *this.FieldSint64 != *that1.FieldSint64 {
+			return false
+		}
+	}
+	if this.FieldFixed32 != that1.FieldFixed32 {
+		if this.FieldFixed32 == nil || that1.FieldFixed32 == nil {
+			return false
+		}
+		if *this.FieldFixed32 != *that1.FieldFixed32 {
+			return false
+		}
+	}
+	if this.FieldFixed64 != that1.FieldFixed64 {
+		if this.FieldFixed64 == nil || that1.FieldFixed64 == nil {
+			return false
+		}
+		if *this.FieldFixed64 != *that1.FieldFixed64 {
+			return false
+		}
+	}
+	if this.FieldSfixed32 != that1.FieldSfixed32 {
+		if this.FieldSfixed32 == nil || that1.FieldSfixed32 == nil {
+			return false
+		}
+		if *this.FieldSfixed32 != *that1.FieldSfixed32 {
+			return false
+		}
+	}
+	if this.FieldSfixed64 != that1.FieldSfixed64 {
+		if this.FieldSfixed64 == nil || that1.FieldSfixed64 == nil {
+			return false
+		}
+		if *this.FieldSfixed64 != *that1.FieldSfixed64 {
+			return false
+		}
+	}
+	if this.FieldBool != that1.FieldBool {
+		if this.FieldBool == nil || that1.FieldBool == nil {
+			return false
+		}
+		if *this.FieldBool != *that1.FieldBool {
+			return false
+		}
+	}
+	if this.FieldString != that1.FieldString {
+		if this.FieldString == nil || that1.FieldString == nil {
+			return false
+		}
+		if *this.FieldString != *that1.FieldString {
+			return false
+		}
+	}
+	if !bytes.Equal(this.FieldBytes, that1.FieldBytes) {
+		return false
+	}
+	return true
+}
+
+func (this *AllRepeatedScalars) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*AllRepeatedScalars)
+	if !ok {
+		that2, ok := that.(AllRepeatedScalars)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.FieldDouble) != len(that1.FieldDouble) {
+		return false
+	}
+	for i := range this.FieldDouble {
+		if this.FieldDouble[i] != that1.FieldDouble[i] {
+			return false
+		}
+	}
+	if len(this.FieldFloat) != len(that1.FieldFloat) {
+		return false
+	}
+	for i := range this.FieldFloat {
+		if this.FieldFloat[i] != that1.FieldFloat[i] {
+			return false
+		}
+	}
+	if len(this.FieldInt32) != len(that1.FieldInt32) {
+		return false
+	}
+	for i := range this.FieldInt32 {
+		if this.FieldInt32[i] != that1.FieldInt32[i] {
+			return false
+		}
+	}
+	if len(this.FieldInt64) != len(that1.FieldInt64) {
+		return false
+	}
+	for i := range this.FieldInt64 {
+		if this.FieldInt64[i] != that1.FieldInt64[i] {
+			return false
+		}
+	}
+	if len(this.FieldUint32) != len(that1.FieldUint32) {
+		return false
+	}
+	for i := range this.FieldUint32 {
+		if this.FieldUint32[i] != that1.FieldUint32[i] {
+			return false
+		}
+	}
+	if len(this.FieldUint64) != len(that1.FieldUint64) {
+		return false
+	}
+	for i := range this.FieldUint64 {
+		if this.FieldUint64[i] != that1.FieldUint64[i] {
+			return false
+		}
+	}
+	if len(this.FieldSint32) != len(that1.FieldSint32) {
+		return false
+	}
+	for i := range this.FieldSint32 {
+		if this.FieldSint32[i] != that1.FieldSint32[i] {
+			return false
+		}
+	}
+	if len(this.FieldSint64) != len(that1.FieldSint64) {
+		return false
+	}
+	for i := range this.FieldSint64 {
+		if this.FieldSint64[i] != that1.FieldSint64[i] {
+			return false
+		}
+	}
+	if len(this.FieldFixed32) != len(that1.FieldFixed32) {
+		return false
+	}
+	for i := range this.FieldFixed32 {
+		if this.FieldFixed32[i] != that1.FieldFixed32[i] {
+			return false
+		}
+	}
+	if len(this.FieldFixed64) != len(that1.FieldFixed64) {
+		return false
+	}
+	for i := range this.FieldFixed64 {
+		if this.FieldFixed64[i] != that1.FieldFixed64[i] {
+			return false
+		}
+	}
+	if len(this.FieldSfixed32) != len(that1.FieldSfixed32) {
+		return false
+	}
+	for i := range this.FieldSfixed32 {
+		if this.FieldSfixed32[i] != that1.FieldSfixed32[i] {
+			return false
+		}
+	}
+	if len(this.FieldSfixed64) != len(that1.FieldSfixed64) {
+		return false
+	}
+	for i := range this.FieldSfixed64 {
+		if this.FieldSfixed64[i] != that1.FieldSfixed64[i] {
+			return false
+		}
+	}
+	if len(this.FieldBool) != len(that1.FieldBool) {
+		return false
+	}
+	for i := range this.FieldBool {
+		if this.FieldBool[i] != that1.FieldBool[i] {
+			return false
+		}
+	}
+	if len(this.FieldString) != len(that1.FieldString) {
+		return false
+	}
+	for i := range this.FieldString {
+		if this.FieldString[i] != that1.FieldString[i] {
+			return false
+		}
+	}
+	if len(this.FieldBytes) != len(that1.FieldBytes) {
+		return false
+	}
+	for i := range this.FieldBytes {
+		if !bytes.Equal(this.FieldBytes[i], that1.FieldBytes[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *OneofVariants) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*OneofVariants)
+	if !ok {
+		that2, ok := that.(OneofVariants)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Value != that1.Value {
+		return false
+	}
+	return true
+}
+
+func (this *Outer) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Outer)
+	if !ok {
+		that2, ok := that.(Outer)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Middle.Equal(that1.Middle) {
+		return false
+	}
+	if len(this.Middles) != len(that1.Middles) {
+		return false
+	}
+	for i := range this.Middles {
+		if !this.Middles[i].Equal(that1.Middles[i]) {
+			return false
+		}
+	}
+	if this.Name != that1.Name {
+		return false
+	}
+	return true
+}
+
+func (this *Middle) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Middle)
+	if !ok {
+		that2, ok := that.(Middle)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Inner.Equal(that1.Inner) {
+		return false
+	}
+	if len(this.Inners) != len(that1.Inners) {
+		return false
+	}
+	for i := range this.Inners {
+		if !this.Inners[i].Equal(that1.Inners[i]) {
+			return false
+		}
+	}
+	if this.Value != that1.Value {
+		return false
+	}
+	return true
+}
+
+func (this *Inner) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Inner)
+	if !ok {
+		that2, ok := that.(Inner)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Data != that1.Data {
+		return false
+	}
+	if !bytes.Equal(this.Raw, that1.Raw) {
+		return false
+	}
+	if this.SignedVal != that1.SignedVal {
+		return false
+	}
+	if this.FixedVal != that1.FixedVal {
+		return false
+	}
+	return true
+}
+
+func (this *HighFieldNumbers) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*HighFieldNumbers)
+	if !ok {
+		that2, ok := that.(HighFieldNumbers)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Field1 != that1.Field1 {
+		return false
+	}
+	if this.Field16 != that1.Field16 {
+		return false
+	}
+	if this.Field128 != that1.Field128 {
+		return false
+	}
+	if this.Field2048 != that1.Field2048 {
+		return false
+	}
+	if this.Field16384 != that1.Field16384 {
+		return false
+	}
+	return true
+}
+
+func (this *WithEnum) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*WithEnum)
+	if !ok {
+		that2, ok := that.(WithEnum)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Color != that1.Color {
+		return false
+	}
+	if len(this.Colors) != len(that1.Colors) {
+		return false
+	}
+	for i := range this.Colors {
+		if this.Colors[i] != that1.Colors[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Empty) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Empty)
+	if !ok {
+		that2, ok := that.(Empty)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	return true
+}
+
+func (this *OnlyRepeated) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*OnlyRepeated)
+	if !ok {
+		that2, ok := that.(OnlyRepeated)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Names) != len(that1.Names) {
+		return false
+	}
+	for i := range this.Names {
+		if this.Names[i] != that1.Names[i] {
+			return false
+		}
+	}
+	if len(this.Values) != len(that1.Values) {
+		return false
+	}
+	for i := range this.Values {
+		if this.Values[i] != that1.Values[i] {
+			return false
+		}
+	}
+	if len(this.Items) != len(that1.Items) {
+		return false
+	}
+	for i := range this.Items {
+		if !this.Items[i].Equal(that1.Items[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *Container) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Container)
+	if !ok {
+		that2, ok := that.(Container)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.Variant.Equal(that1.Variant) {
+		return false
+	}
+	if !this.Scalars.Equal(that1.Scalars) {
+		return false
+	}
+	if len(this.Variants) != len(that1.Variants) {
+		return false
+	}
+	for i := range this.Variants {
+		if !this.Variants[i].Equal(that1.Variants[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (this *AllMaps) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*AllMaps)
+	if !ok {
+		that2, ok := that.(AllMaps)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.MapInt32Int32) != len(that1.MapInt32Int32) {
+		return false
+	}
+	for k, v := range this.MapInt32Int32 {
+		v2, ok := that1.MapInt32Int32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapInt64Int64) != len(that1.MapInt64Int64) {
+		return false
+	}
+	for k, v := range this.MapInt64Int64 {
+		v2, ok := that1.MapInt64Int64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapUint32Uint32) != len(that1.MapUint32Uint32) {
+		return false
+	}
+	for k, v := range this.MapUint32Uint32 {
+		v2, ok := that1.MapUint32Uint32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapUint64Uint64) != len(that1.MapUint64Uint64) {
+		return false
+	}
+	for k, v := range this.MapUint64Uint64 {
+		v2, ok := that1.MapUint64Uint64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapSint32Sint32) != len(that1.MapSint32Sint32) {
+		return false
+	}
+	for k, v := range this.MapSint32Sint32 {
+		v2, ok := that1.MapSint32Sint32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapSint64Sint64) != len(that1.MapSint64Sint64) {
+		return false
+	}
+	for k, v := range this.MapSint64Sint64 {
+		v2, ok := that1.MapSint64Sint64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapFixed32Fixed32) != len(that1.MapFixed32Fixed32) {
+		return false
+	}
+	for k, v := range this.MapFixed32Fixed32 {
+		v2, ok := that1.MapFixed32Fixed32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapFixed64Fixed64) != len(that1.MapFixed64Fixed64) {
+		return false
+	}
+	for k, v := range this.MapFixed64Fixed64 {
+		v2, ok := that1.MapFixed64Fixed64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapSfixed32Sfixed32) != len(that1.MapSfixed32Sfixed32) {
+		return false
+	}
+	for k, v := range this.MapSfixed32Sfixed32 {
+		v2, ok := that1.MapSfixed32Sfixed32[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapSfixed64Sfixed64) != len(that1.MapSfixed64Sfixed64) {
+		return false
+	}
+	for k, v := range this.MapSfixed64Sfixed64 {
+		v2, ok := that1.MapSfixed64Sfixed64[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapBoolBool) != len(that1.MapBoolBool) {
+		return false
+	}
+	for k, v := range this.MapBoolBool {
+		v2, ok := that1.MapBoolBool[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapStringString) != len(that1.MapStringString) {
+		return false
+	}
+	for k, v := range this.MapStringString {
+		v2, ok := that1.MapStringString[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapStringBytes) != len(that1.MapStringBytes) {
+		return false
+	}
+	for k, v := range this.MapStringBytes {
+		v2, ok := that1.MapStringBytes[k]
+		if !ok {
+			return false
+		}
+		if !bytes.Equal(v, v2) {
+			return false
+		}
+	}
+	if len(this.MapInt32Float) != len(that1.MapInt32Float) {
+		return false
+	}
+	for k, v := range this.MapInt32Float {
+		v2, ok := that1.MapInt32Float[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapInt32Double) != len(that1.MapInt32Double) {
+		return false
+	}
+	for k, v := range this.MapInt32Double {
+		v2, ok := that1.MapInt32Double[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	if len(this.MapStringMessage) != len(that1.MapStringMessage) {
+		return false
+	}
+	for k, v := range this.MapStringMessage {
+		v2, ok := that1.MapStringMessage[k]
+		if !ok {
+			return false
+		}
+		if !v.Equal(v2) {
+			return false
+		}
+	}
+	if len(this.MapStringEnum) != len(that1.MapStringEnum) {
+		return false
+	}
+	for k, v := range this.MapStringEnum {
+		v2, ok := that1.MapStringEnum[k]
+		if !ok {
+			return false
+		}
+		if v != v2 {
+			return false
+		}
+	}
+	return true
 }

--- a/test/equal_test.go
+++ b/test/equal_test.go
@@ -1,0 +1,247 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ks "wiresmith/gen/test/kitchensink/v1"
+)
+
+func TestEqual_NilReceiver(t *testing.T) {
+	var a *ks.AllScalars
+	var b *ks.AllScalars
+	assert.True(t, a.Equal(b), "two nil pointers must be equal")
+	assert.True(t, a.Equal(nil), "nil pointer and nil interface must be equal")
+}
+
+func TestEqual_NilVsZero(t *testing.T) {
+	var a *ks.AllScalars
+	b := &ks.AllScalars{}
+	assert.False(t, a.Equal(b), "nil pointer must not equal zero value")
+	assert.False(t, b.Equal(a), "zero value must not equal nil pointer")
+	assert.False(t, b.Equal(nil), "zero value must not equal nil interface")
+}
+
+func TestEqual_PointerAndValue(t *testing.T) {
+	a := &ks.AllScalars{FieldInt32: 42}
+	b := ks.AllScalars{FieldInt32: 42}
+	assert.True(t, a.Equal(b), "pointer and value with same fields must be equal")
+}
+
+func TestEqual_WrongType(t *testing.T) {
+	a := &ks.AllScalars{FieldInt32: 42}
+	assert.False(t, a.Equal("not a proto"), "must return false for wrong type")
+	assert.False(t, a.Equal(42), "must return false for wrong type")
+}
+
+func TestEqual_DifferentScalar(t *testing.T) {
+	a := &ks.AllScalars{FieldInt32: 1}
+	b := &ks.AllScalars{FieldInt32: 2}
+	assert.False(t, a.Equal(b))
+}
+
+func TestEqual_Bytes_NonOptional(t *testing.T) {
+	// For non-optional bytes, nil and empty are both the zero value.
+	a := &ks.AllScalars{FieldBytes: nil}
+	b := &ks.AllScalars{FieldBytes: []byte{}}
+	assert.True(t, a.Equal(b), "non-optional bytes: nil and empty are the same zero value")
+}
+
+func TestEqual_Bytes_Optional_NilVsEmpty(t *testing.T) {
+	// For optional bytes, nil means "unset" and []byte{} means "set to empty".
+	a := &ks.AllOptionalScalars{FieldBytes: nil}
+	b := &ks.AllOptionalScalars{FieldBytes: []byte{}}
+	assert.False(t, a.Equal(b), "optional bytes: nil (unset) must not equal empty (set)")
+	assert.False(t, b.Equal(a))
+}
+
+func TestEqual_Bytes_Optional_BothNil(t *testing.T) {
+	a := &ks.AllOptionalScalars{FieldBytes: nil}
+	b := &ks.AllOptionalScalars{FieldBytes: nil}
+	assert.True(t, a.Equal(b))
+}
+
+func TestEqual_Bytes_Optional_BothEmpty(t *testing.T) {
+	a := &ks.AllOptionalScalars{FieldBytes: []byte{}}
+	b := &ks.AllOptionalScalars{FieldBytes: []byte{}}
+	assert.True(t, a.Equal(b))
+}
+
+func TestEqual_Bytes_Optional_SameContent(t *testing.T) {
+	a := &ks.AllOptionalScalars{FieldBytes: []byte{0x01, 0x02}}
+	b := &ks.AllOptionalScalars{FieldBytes: []byte{0x01, 0x02}}
+	assert.True(t, a.Equal(b))
+}
+
+// --- Oneof Equal ---
+
+func TestEqual_Oneof_BothUnset(t *testing.T) {
+	a := &ks.OneofVariants{Value: nil}
+	b := &ks.OneofVariants{Value: nil}
+	assert.True(t, a.Equal(b))
+}
+
+func TestEqual_Oneof_OneUnset(t *testing.T) {
+	a := &ks.OneofVariants{Value: nil}
+	b := &ks.OneofVariants{Value: &ks.OneofVariants_Int32Value{Int32Value: 1}}
+	assert.False(t, a.Equal(b))
+	assert.False(t, b.Equal(a))
+}
+
+func TestEqual_Oneof_SameTypeSameValue(t *testing.T) {
+	// Two independently allocated variants with the same value must be equal.
+	a := &ks.OneofVariants{Value: &ks.OneofVariants_StringValue{StringValue: "hello"}}
+	b := &ks.OneofVariants{Value: &ks.OneofVariants_StringValue{StringValue: "hello"}}
+	assert.True(t, a.Equal(b), "same oneof variant type and value must be equal")
+}
+
+func TestEqual_Oneof_SameTypeDifferentValue(t *testing.T) {
+	a := &ks.OneofVariants{Value: &ks.OneofVariants_Int64Value{Int64Value: 1}}
+	b := &ks.OneofVariants{Value: &ks.OneofVariants_Int64Value{Int64Value: 2}}
+	assert.False(t, a.Equal(b))
+}
+
+func TestEqual_Oneof_DifferentTypes(t *testing.T) {
+	a := &ks.OneofVariants{Value: &ks.OneofVariants_Int32Value{Int32Value: 42}}
+	b := &ks.OneofVariants{Value: &ks.OneofVariants_Int64Value{Int64Value: 42}}
+	assert.False(t, a.Equal(b), "different oneof variant types must not be equal")
+}
+
+func TestEqual_Oneof_BytesVariant(t *testing.T) {
+	a := &ks.OneofVariants{Value: &ks.OneofVariants_BytesValue{BytesValue: []byte{0x01}}}
+	b := &ks.OneofVariants{Value: &ks.OneofVariants_BytesValue{BytesValue: []byte{0x01}}}
+	assert.True(t, a.Equal(b))
+
+	c := &ks.OneofVariants{Value: &ks.OneofVariants_BytesValue{BytesValue: []byte{0x02}}}
+	assert.False(t, a.Equal(c))
+}
+
+func TestEqual_Oneof_AfterUnmarshal(t *testing.T) {
+	// The core bug scenario: two messages created via independent unmarshals
+	// must compare equal if they have the same oneof content.
+	src := &ks.OneofVariants{Value: &ks.OneofVariants_StringValue{StringValue: "test"}}
+	b, err := src.Marshal()
+	assert.NoError(t, err)
+
+	var dst1, dst2 ks.OneofVariants
+	assert.NoError(t, dst1.Unmarshal(b))
+	assert.NoError(t, dst2.Unmarshal(b))
+	assert.True(t, dst1.Equal(&dst2), "independently unmarshaled messages must be equal")
+}
+
+// --- Nested message Equal ---
+
+func TestEqual_NestedMessage(t *testing.T) {
+	a := &ks.Outer{
+		Middle: ks.Middle{Inner: ks.Inner{Data: "same"}},
+		Name:   "outer",
+	}
+	b := &ks.Outer{
+		Middle: ks.Middle{Inner: ks.Inner{Data: "same"}},
+		Name:   "outer",
+	}
+	assert.True(t, a.Equal(b))
+
+	c := &ks.Outer{
+		Middle: ks.Middle{Inner: ks.Inner{Data: "different"}},
+		Name:   "outer",
+	}
+	assert.False(t, a.Equal(c))
+}
+
+// --- Repeated Equal ---
+
+func TestEqual_RepeatedLength(t *testing.T) {
+	a := &ks.OnlyRepeated{Names: []string{"a", "b"}}
+	b := &ks.OnlyRepeated{Names: []string{"a"}}
+	assert.False(t, a.Equal(b))
+}
+
+func TestEqual_RepeatedContent(t *testing.T) {
+	a := &ks.OnlyRepeated{Names: []string{"a", "b"}}
+	b := &ks.OnlyRepeated{Names: []string{"a", "c"}}
+	assert.False(t, a.Equal(b))
+}
+
+func TestEqual_RepeatedNilVsEmpty(t *testing.T) {
+	a := &ks.OnlyRepeated{Names: nil}
+	b := &ks.OnlyRepeated{Names: []string{}}
+	assert.True(t, a.Equal(b), "nil and empty slice are both zero value for repeated")
+}
+
+// --- Map Equal ---
+
+func TestEqual_MapDifferentKeys(t *testing.T) {
+	a := &ks.AllMaps{MapStringString: map[string]string{"a": "1"}}
+	b := &ks.AllMaps{MapStringString: map[string]string{"b": "1"}}
+	assert.False(t, a.Equal(b))
+}
+
+func TestEqual_MapDifferentValues(t *testing.T) {
+	a := &ks.AllMaps{MapStringString: map[string]string{"a": "1"}}
+	b := &ks.AllMaps{MapStringString: map[string]string{"a": "2"}}
+	assert.False(t, a.Equal(b))
+}
+
+func TestEqual_MapSame(t *testing.T) {
+	a := &ks.AllMaps{MapStringString: map[string]string{"a": "1", "b": "2"}}
+	b := &ks.AllMaps{MapStringString: map[string]string{"b": "2", "a": "1"}}
+	assert.True(t, a.Equal(b))
+}
+
+func TestEqual_MapNilVsEmpty(t *testing.T) {
+	a := &ks.AllMaps{MapStringString: nil}
+	b := &ks.AllMaps{MapStringString: map[string]string{}}
+	assert.True(t, a.Equal(b), "nil and empty map are both zero value")
+}
+
+func TestEqual_MapMessageValue(t *testing.T) {
+	a := &ks.AllMaps{MapStringMessage: map[string]ks.Inner{
+		"k": {Data: "v", SignedVal: 1},
+	}}
+	b := &ks.AllMaps{MapStringMessage: map[string]ks.Inner{
+		"k": {Data: "v", SignedVal: 1},
+	}}
+	assert.True(t, a.Equal(b))
+
+	c := &ks.AllMaps{MapStringMessage: map[string]ks.Inner{
+		"k": {Data: "v", SignedVal: 2},
+	}}
+	assert.False(t, a.Equal(c))
+}
+
+func TestEqual_MapBytesValue(t *testing.T) {
+	a := &ks.AllMaps{MapStringBytes: map[string][]byte{"k": {0x01}}}
+	b := &ks.AllMaps{MapStringBytes: map[string][]byte{"k": {0x01}}}
+	assert.True(t, a.Equal(b))
+
+	c := &ks.AllMaps{MapStringBytes: map[string][]byte{"k": {0x02}}}
+	assert.False(t, a.Equal(c))
+}
+
+// --- Empty message Equal ---
+
+func TestEqual_Empty(t *testing.T) {
+	a := &ks.Empty{}
+	b := &ks.Empty{}
+	assert.True(t, a.Equal(b))
+	assert.True(t, a.Equal(ks.Empty{}), "pointer vs value")
+}
+
+// --- Container with oneof ---
+
+func TestEqual_ContainerOneof(t *testing.T) {
+	a := &ks.Container{
+		Variant: ks.OneofVariants{Value: &ks.OneofVariants_BoolValue{BoolValue: true}},
+	}
+	b := &ks.Container{
+		Variant: ks.OneofVariants{Value: &ks.OneofVariants_BoolValue{BoolValue: true}},
+	}
+	assert.True(t, a.Equal(b))
+
+	c := &ks.Container{
+		Variant: ks.OneofVariants{Value: &ks.OneofVariants_BoolValue{BoolValue: false}},
+	}
+	assert.False(t, a.Equal(c))
+}

--- a/test/kitchen_sink_test.go
+++ b/test/kitchen_sink_test.go
@@ -16,6 +16,7 @@ func roundTrip[T interface {
 	Marshal() ([]byte, error)
 	Unmarshal([]byte) error
 	Size() int
+	Equal(interface{}) bool
 }](t *testing.T, src T) []byte {
 	t.Helper()
 
@@ -26,6 +27,7 @@ func roundTrip[T interface {
 	dst := reflect.New(reflect.TypeOf(src).Elem()).Interface().(T)
 	require.NoError(t, dst.Unmarshal(b))
 	assert.Equal(t, src, dst, "unmarshal must reproduce original")
+	assert.True(t, src.Equal(dst), "Equal() must agree with assert.Equal")
 
 	b2, err := dst.Marshal()
 	require.NoError(t, err)

--- a/test/map_test.go
+++ b/test/map_test.go
@@ -19,6 +19,7 @@ func mapRoundTrip[T interface {
 	Marshal() ([]byte, error)
 	Unmarshal([]byte) error
 	Size() int
+	Equal(interface{}) bool
 }](t *testing.T, src T) {
 	t.Helper()
 
@@ -29,6 +30,7 @@ func mapRoundTrip[T interface {
 	dst := newZero(src)
 	require.NoError(t, dst.Unmarshal(b))
 	assert.Equal(t, src, dst, "unmarshal must reproduce original")
+	assert.True(t, src.Equal(dst), "Equal() must agree with assert.Equal")
 }
 
 // newZero returns a new zero-value instance of the same concrete type.


### PR DESCRIPTION
## Summary
- Generate `Equal(that interface{}) bool` for every message type — handles scalars, `bytes.Equal`, recursive messages, maps, repeated fields, optional pointers, and oneofs
- Preserve leading comments from `.proto` source files on generated structs, fields, oneofs, enum types, and enum values (via `protocompile.SourceInfoStandard`)
- `Marshal()` returns non-nil empty `[]byte` for zero-size messages instead of `nil`
- Add `MIMIR.md` documenting remaining mimir-compat branch differences

## Test plan
- [x] `make generate-ours` succeeds
- [x] `go build ./...` succeeds
- [x] `go test ./test/ -v` — all tests pass
- [ ] `make conformance` passes (Docker-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)