### PR TITLE
feat: add .pb.go suffix, String() methods, enum maps, and type registration

### DIFF
--- a/.claude/skills/compete/SKILL.md
+++ b/.claude/skills/compete/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: compete
+description: Analyze how competing protobuf libraries (gogoproto, vtprotobuf, official Go proto) implement a specific feature. Reports implementation approach, test patterns worth porting, and gaps in wiresmith's coverage.
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: Bash, Read, Grep, Glob, Agent, WebFetch, WebSearch
+---
+
+# Competitor Library Analysis
+
+Analyze how competing protobuf libraries implement a feature and identify test patterns to port to wiresmith.
+
+## Steps
+
+1. Search wiresmith (`compiler/`, `gen/`, `test/`) to understand the current implementation and test coverage.
+
+2. For each competitor, fetch implementation and tests via `raw.githubusercontent.com` URLs (use `WebSearch` to locate files if needed):
+   - **gogoproto**: `gogo/protobuf` — `proto/`, `protoc-gen-gogo/generator/`
+   - **vtprotobuf**: `planetscale/vtprotobuf` — `generator/`, `features/`
+   - **official Go proto**: `protocolbuffers/protobuf-go` — `proto/`, `internal/impl/`, `encoding/protowire/`
+
+3. Report: for each library, summarize approach differences and notable test edge cases (encoding corner cases, malformed input, cross-library compat). End with **recommended actions** — specific tests to add to wiresmith, with rationale. Focus on actionable gaps, not implementation suggestions unless there's a correctness issue.

--- a/.claude/skills/validate/SKILL.md
+++ b/.claude/skills/validate/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: validate
+description: Run full pre-push validation — regenerate code, check freshness, run tests, and run conformance. Use before pushing any changes to protobuf codegen or marshal/unmarshal code.
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Pre-Push Validation
+
+Run these steps sequentially. Stop on first failure. Show full output for every step — the whole point is to see evidence, not summaries.
+
+1. `make generate-ours`
+2. `git diff --stat --exit-code gen/` — if stale, show the diff and stage changes, but continue
+3. `go test ./test/ ./compiler/... -v`
+4. `make conformance` — compare counts against `conformance/failure_list.txt`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,9 @@ All commands are available via `make`:
 - **bufbuild/protocompile for parsing**: Reuses the buf compiler for proto parsing and type resolution instead of a custom parser.
 - **Field presence bitmap**: Singular non-optional, non-oneof fields get a `fieldsPresent` bitmap (`[N]uint64`) that tracks which fields were seen during `Unmarshal`. Generated `Has<Field>()` methods let callers distinguish "field absent" from "field set to zero value". The bitmap is not serialized. Repeated, map, optional, and oneof fields are excluded — they already have presence semantics via nil slice/pointer/interface. **Note on optional bytes**: optional bytes fields use `[]byte` (same Go type as regular bytes), with `nil` = absent and non-nil = present. This matches gogoproto/official protobuf behavior. The distinction is via nil-check, not the bitmap — `[]byte{}` is "present but empty", `nil` is "absent".
 - **Getter methods**: `Get<Field>()` methods are generated for all fields (nil-safe like gogoproto). For value-type message fields, the getter returns `*MessageType` and uses the presence bitmap to return `nil` when the field was absent from the wire. Optional fields dereference the pointer, oneof fields type-assert, repeated/map fields return the slice/map.
-- **Reset/ProtoMessage**: `Reset()` zeroes the struct (`*m = Type{}`). `ProtoMessage()` is a no-op marker method, matching the standard `proto.Message` interface shape.
+- **Reset/ProtoMessage/String**: `Reset()` zeroes the struct (`*m = Type{}`). `ProtoMessage()` is a no-op marker method, matching the standard `proto.Message` interface shape. `String()` uses `fmt.Sprintf("%v", *m)`.
+- **Enum name maps**: Each enum gets `TypeName_name` (int32→string) and `TypeName_value` (string→int32) maps, plus a `String()` method. Matches gogoproto convention of using bare value names.
+- **Type registration**: Generated `init()` registers all messages and enums via `protohelpers.RegisterType`/`RegisterEnum`. No gogo/protobuf dependency — uses a lightweight self-hosted registry in `gen/protohelpers/`.
 
 ## Supported proto3 features
 

--- a/MIMIR.md
+++ b/MIMIR.md
@@ -7,22 +7,12 @@ Already implemented:
 - `Marshal` returns non-nil slice for empty messages — #32
 - `Equal(that interface{}) bool` per-message equality — #32
 - Proto source comments preserved in generated code — #32
-
-## Method Signature Changes (generally applicable)
-
-### `MarshalToSizedBuffer` returns `(int, error)` instead of `int`
-Current: `func (m *T) MarshalToSizedBuffer(dAtA []byte) int`
-Target:  `func (m *T) MarshalToSizedBuffer(dAtA []byte) (int, error)`
-- All internal callers (nested message marshal) must propagate the error.
-- `MessageType.EmitMarshal` and `EmitValueMarshal` in `compiler/types/message.go` already emit `(int, error)` return handling — the emitter itself needs updating in `emit_marshal.go`.
-
-### New `MarshalTo` method
-```go
-func (m *T) MarshalTo(dAtA []byte) (int, error) {
-    size := m.Size()
-    return m.MarshalToSizedBuffer(dAtA[:size])
-}
-```
+- `MarshalToSizedBuffer` returns `(int, error)` and `MarshalTo` method — #34
+- `Reset()`, `ProtoMessage()`, `String()` on all messages — #34
+- Getter methods (`Get*()`) for all fields — #34
+- Enum name/value maps and `String()` method — #35
+- Type registration via `protohelpers.RegisterType`/`RegisterEnum` in `init()` — #35
+- `.pb.go` output file suffix — #35
 
 ## Gogo-Specific Features (require GogoCompat flag)
 
@@ -32,11 +22,9 @@ These are NOT generally applicable — they only matter for gogo/protobuf drop-i
 - `protobuf:"varint,1,opt,name=foo,json=fooBar,proto3"` tags on struct fields
 - `protobuf_oneof:"field_name"` tags on oneof interface fields
 
-### Gogo method set
-- `Reset()`, `ProtoMessage()`, `String()`, `GoString()`
+### Gogo method set (remaining)
+- `GoString()`
 - `XXX_*` methods (deprecated but required for gogo compat)
-- Getter methods (`Get*()` for each field)
-- Registration: `proto.RegisterType()` / `proto.RegisterEnum()` in `init()`
 
 ### Pointer semantics
 - `(gogoproto.nullable)` support — message fields as `*T` instead of `T`
@@ -57,6 +45,5 @@ These are NOT generally applicable — they only matter for gogo/protobuf drop-i
 - `ProtoPaths []string` and `ProtoFiles []string` on Generator
 - `multiPathResolver` for cross-directory proto imports
 
-### Output conventions
-- `.pb.go` suffix instead of `.go`
+### Output conventions (remaining)
 - `go_package` option for output directory

--- a/TEMPO.md
+++ b/TEMPO.md
@@ -22,7 +22,15 @@ wiresmith \
   --helpers_import=github.com/grafana/tempo/pkg/tempopb/protohelpers
 ```
 
-## Compiler Changes
+## Already Implemented
+
+- Getter methods (`GetXxx()`) for all fields — #34
+- `Reset()`, `ProtoMessage()`, `String()` on all messages — #34, #35
+- Enum name maps (`_name`/`_value`) and `String()` method — #35
+- `.pb.go` output file suffix — #35
+- Type registration via `protohelpers.RegisterType`/`RegisterEnum` in `init()` — #35
+
+## Compiler Changes (remaining)
 
 ### Recursive directory scanning
 
@@ -34,26 +42,6 @@ wiresmith \
 - `goDeclaredPkgName`: with `--strip_prefix`, uses the last path component (`v1`) instead of the concatenated form (`commonv1`)
 - `goImportPath`: uses `--import_base` instead of `module/gen/`
 - `helpersImportPath`: uses `--helpers_import` if set
-
-### Getter methods (`emit_getters.go`)
-
-Generated `GetXxx()` for every field. Required because Tempo code uses nil-safe getter chains like `rs.GetResource().GetAttributes()`.
-
-- Scalar/enum fields: return value, zero if nil receiver
-- Message fields (value types): return `*T` (pointer to the value field), nil if nil receiver
-- Repeated/map fields: return slice/map, nil if nil receiver
-- Oneof interface: return the interface, nil if nil receiver
-- Oneof variant getters: type-assert the interface and extract the value
-
-### Proto-compat methods (`emit_compat.go`)
-
-Generated `Reset()`, `String()`, `ProtoMessage()` for every message. `ProtoMessage()` is needed as a marker for proto.Message interface satisfaction. `Reset()` is used by some Tempo code paths.
-
-### Enum name maps and String() (`emit_enum.go`)
-
-- Constants use the parent message prefix: `Status_STATUS_CODE_ERROR`
-- Name maps use bare enum value names (no prefix): `"STATUS_CODE_ERROR"`
-- This matches gogoproto behavior where `String()` returns `"STATUS_CODE_ERROR"`, not `"Status_STATUS_CODE_ERROR"`
 
 ### Struct tags (`emit_struct.go`)
 

--- a/compiler/generator/emit_enum.go
+++ b/compiler/generator/emit_enum.go
@@ -24,11 +24,17 @@ func (fg *FileGenerator) emitEnum(ed protoreflect.EnumDescriptor) {
 	}
 	fmt.Fprintf(fg.body, ")\n\n")
 
-	// Name map: int32 → string
+	// Name map: int32 → string (first name wins for aliased values)
 	fmt.Fprintf(fg.body, "var %s_name = map[int32]string{\n", typeName)
+	seenNumbers := make(map[int32]bool)
 	for i := 0; i < ed.Values().Len(); i++ {
 		v := ed.Values().Get(i)
-		fmt.Fprintf(fg.body, "\t%d: %q,\n", v.Number(), string(v.Name()))
+		num := int32(v.Number())
+		if seenNumbers[num] {
+			continue
+		}
+		seenNumbers[num] = true
+		fmt.Fprintf(fg.body, "\t%d: %q,\n", num, string(v.Name()))
 	}
 	fmt.Fprintf(fg.body, "}\n\n")
 

--- a/compiler/generator/emit_enum.go
+++ b/compiler/generator/emit_enum.go
@@ -23,4 +23,29 @@ func (fg *FileGenerator) emitEnum(ed protoreflect.EnumDescriptor) {
 		fmt.Fprintf(fg.body, "\t%s %s = %d\n", string(v.Name()), typeName, v.Number())
 	}
 	fmt.Fprintf(fg.body, ")\n\n")
+
+	// Name map: int32 → string
+	fmt.Fprintf(fg.body, "var %s_name = map[int32]string{\n", typeName)
+	for i := 0; i < ed.Values().Len(); i++ {
+		v := ed.Values().Get(i)
+		fmt.Fprintf(fg.body, "\t%d: %q,\n", v.Number(), string(v.Name()))
+	}
+	fmt.Fprintf(fg.body, "}\n\n")
+
+	// Value map: string → int32
+	fmt.Fprintf(fg.body, "var %s_value = map[string]int32{\n", typeName)
+	for i := 0; i < ed.Values().Len(); i++ {
+		v := ed.Values().Get(i)
+		fmt.Fprintf(fg.body, "\t%q: %d,\n", string(v.Name()), v.Number())
+	}
+	fmt.Fprintf(fg.body, "}\n\n")
+
+	// String() method
+	fmt.Fprintf(fg.body, "func (x %s) String() string {\n", typeName)
+	fmt.Fprintf(fg.body, "\tif name, ok := %s_name[int32(x)]; ok {\n", typeName)
+	fmt.Fprintf(fg.body, "\t\treturn name\n")
+	fmt.Fprintf(fg.body, "\t}\n")
+	fmt.Fprintf(fg.body, "\treturn strconv.FormatInt(int64(x), 10)\n")
+	fmt.Fprintf(fg.body, "}\n\n")
+	fg.imports.addImport("strconv", "")
 }

--- a/compiler/generator/emit_has.go
+++ b/compiler/generator/emit_has.go
@@ -58,6 +58,7 @@ func (fg *FileGenerator) emitHasMethods(md protoreflect.MessageDescriptor) {
 		wordIndex := pf.bitIndex / 64
 		bitOffset := pf.bitIndex % 64
 		fmt.Fprintf(fg.body, "func (m *%s) Has%s() bool {\n", name, goName)
+		fmt.Fprintf(fg.body, "\tif m == nil {\n\t\treturn false\n\t}\n")
 		fmt.Fprintf(fg.body, "\treturn m.fieldsPresent[%d]&(1<<%d) != 0\n", wordIndex, bitOffset)
 		fmt.Fprintf(fg.body, "}\n\n")
 	}

--- a/compiler/generator/emit_registration.go
+++ b/compiler/generator/emit_registration.go
@@ -1,0 +1,68 @@
+package generator
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func (fg *FileGenerator) emitRegistration(fd protoreflect.FileDescriptor) {
+	fg.body.WriteString("func init() {\n")
+	fg.emitEnumRegistrations(fd)
+	fg.emitMessageRegistrations(fd)
+	fg.body.WriteString("}\n")
+
+	fg.imports.addImport(fg.module+"/gen/protohelpers", "")
+}
+
+func (fg *FileGenerator) emitEnumRegistrations(parent protoreflect.Descriptor) {
+	var enums protoreflect.EnumDescriptors
+	switch p := parent.(type) {
+	case protoreflect.FileDescriptor:
+		enums = p.Enums()
+	case protoreflect.MessageDescriptor:
+		enums = p.Enums()
+	}
+	for i := 0; i < enums.Len(); i++ {
+		ed := enums.Get(i)
+		typeName := goEnumTypeName(ed)
+		fmt.Fprintf(fg.body, "\tprotohelpers.RegisterEnum(%q, %s_name, %s_value)\n",
+			ed.FullName(), typeName, typeName)
+	}
+
+	// Recurse into nested messages
+	var msgs protoreflect.MessageDescriptors
+	switch p := parent.(type) {
+	case protoreflect.FileDescriptor:
+		msgs = p.Messages()
+	case protoreflect.MessageDescriptor:
+		msgs = p.Messages()
+	}
+	for i := 0; i < msgs.Len(); i++ {
+		md := msgs.Get(i)
+		if md.IsMapEntry() {
+			continue
+		}
+		fg.emitEnumRegistrations(md)
+	}
+}
+
+func (fg *FileGenerator) emitMessageRegistrations(parent protoreflect.Descriptor) {
+	var msgs protoreflect.MessageDescriptors
+	switch p := parent.(type) {
+	case protoreflect.FileDescriptor:
+		msgs = p.Messages()
+	case protoreflect.MessageDescriptor:
+		msgs = p.Messages()
+	}
+	for i := 0; i < msgs.Len(); i++ {
+		md := msgs.Get(i)
+		if md.IsMapEntry() {
+			continue
+		}
+		typeName := goMessageTypeName(md)
+		fmt.Fprintf(fg.body, "\tprotohelpers.RegisterType((*%s)(nil), %q)\n",
+			typeName, md.FullName())
+		fg.emitMessageRegistrations(md)
+	}
+}

--- a/compiler/generator/emit_reset.go
+++ b/compiler/generator/emit_reset.go
@@ -27,6 +27,8 @@ func (fg *FileGenerator) emitReset(md protoreflect.MessageDescriptor) {
 	name := goMessageTypeName(md)
 	fmt.Fprintf(fg.body, "func (m *%s) Reset()      { *m = %s{} }\n", name, name)
 	fmt.Fprintf(fg.body, "func (*%s) ProtoMessage() {}\n", name)
-	fmt.Fprintf(fg.body, "func (m *%s) String() string { return fmt.Sprintf(\"%%v\", *m) }\n\n", name)
+	fmt.Fprintf(fg.body, "func (m *%s) String() string {\n", name)
+	fmt.Fprintf(fg.body, "\tif m == nil {\n\t\treturn \"<nil>\"\n\t}\n")
+	fmt.Fprintf(fg.body, "\treturn fmt.Sprintf(\"%%v\", *m)\n}\n\n")
 	fg.imports.addImport("fmt", "")
 }

--- a/compiler/generator/emit_reset.go
+++ b/compiler/generator/emit_reset.go
@@ -26,5 +26,7 @@ func (fg *FileGenerator) emitResetMethods(md protoreflect.MessageDescriptor) {
 func (fg *FileGenerator) emitReset(md protoreflect.MessageDescriptor) {
 	name := goMessageTypeName(md)
 	fmt.Fprintf(fg.body, "func (m *%s) Reset()      { *m = %s{} }\n", name, name)
-	fmt.Fprintf(fg.body, "func (*%s) ProtoMessage() {}\n\n", name)
+	fmt.Fprintf(fg.body, "func (*%s) ProtoMessage() {}\n", name)
+	fmt.Fprintf(fg.body, "func (m *%s) String() string { return fmt.Sprintf(\"%%v\", *m) }\n\n", name)
+	fg.imports.addImport("fmt", "")
 }

--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -106,6 +106,7 @@ func (g *Generator) generateFile(fd protoreflect.FileDescriptor) error {
 	fg.emitAllMarshalMethods(fd)
 	fg.emitAllUnmarshalMethods(fd)
 	fg.emitAllEqualMethods(fd)
+	fg.emitRegistration(fd)
 
 	var out bytes.Buffer
 	fg.emitHeader(&out)
@@ -126,7 +127,7 @@ func (g *Generator) generateFile(fd protoreflect.FileDescriptor) error {
 
 	// Use the proto filename without extension as the Go filename
 	base := filepath.Base(fd.Path())
-	base = strings.TrimSuffix(base, ".proto") + ".go"
+	base = strings.TrimSuffix(base, ".proto") + ".pb.go"
 	outPath := filepath.Join(dir, base)
 
 	return os.WriteFile(outPath, formatted, 0o644)

--- a/compiler/generator/generator_test.go
+++ b/compiler/generator/generator_test.go
@@ -205,7 +205,7 @@ func TestGenerateMatchesCheckedIn(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				if !strings.HasSuffix(rel, ".go") {
+				if !strings.HasSuffix(rel, ".pb.go") {
 					return nil
 				}
 				generatedFiles[rel] = struct{}{}
@@ -247,7 +247,7 @@ func TestGenerateMatchesCheckedIn(t *testing.T) {
 					t.Fatalf("reading checked-in directory %s: %v", dir, err)
 				}
 				for _, e := range entries {
-					if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+					if e.IsDir() || !strings.HasSuffix(e.Name(), ".pb.go") {
 						continue
 					}
 					rel := filepath.Join(dir, e.Name())

--- a/gen/bench/maps/v1/maps.pb.go
+++ b/gen/bench/maps/v1/maps.pb.go
@@ -25,23 +25,42 @@ type Inner struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *MapBench) Reset()         { *m = MapBench{} }
-func (*MapBench) ProtoMessage()    {}
-func (m *MapBench) String() string { return fmt.Sprintf("%v", *m) }
+func (m *MapBench) Reset()      { *m = MapBench{} }
+func (*MapBench) ProtoMessage() {}
+func (m *MapBench) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Inner) Reset()         { *m = Inner{} }
-func (*Inner) ProtoMessage()    {}
-func (m *Inner) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Inner) Reset()      { *m = Inner{} }
+func (*Inner) ProtoMessage() {}
+func (m *Inner) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
 func (m *Inner) HasName() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Inner) HasValue() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Inner) HasData() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 

--- a/gen/bench/maps/v1/maps.pb.go
+++ b/gen/bench/maps/v1/maps.pb.go
@@ -25,11 +25,13 @@ type Inner struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *MapBench) Reset()      { *m = MapBench{} }
-func (*MapBench) ProtoMessage() {}
+func (m *MapBench) Reset()         { *m = MapBench{} }
+func (*MapBench) ProtoMessage()    {}
+func (m *MapBench) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Inner) Reset()      { *m = Inner{} }
-func (*Inner) ProtoMessage() {}
+func (m *Inner) Reset()         { *m = Inner{} }
+func (*Inner) ProtoMessage()    {}
+func (m *Inner) String() string { return fmt.Sprintf("%v", *m) }
 
 func (m *Inner) HasName() bool {
 	return m.fieldsPresent[0]&(1<<0) != 0
@@ -952,4 +954,9 @@ func (this *Inner) Equal(that interface{}) bool {
 		return false
 	}
 	return true
+}
+
+func init() {
+	protohelpers.RegisterType((*MapBench)(nil), "bench.maps.v1.MapBench")
+	protohelpers.RegisterType((*Inner)(nil), "bench.maps.v1.Inner")
 }

--- a/gen/otlp/common/v1/common.pb.go
+++ b/gen/otlp/common/v1/common.pb.go
@@ -175,23 +175,29 @@ type EntityRef struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *AnyValue) Reset()      { *m = AnyValue{} }
-func (*AnyValue) ProtoMessage() {}
+func (m *AnyValue) Reset()         { *m = AnyValue{} }
+func (*AnyValue) ProtoMessage()    {}
+func (m *AnyValue) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ArrayValue) Reset()      { *m = ArrayValue{} }
-func (*ArrayValue) ProtoMessage() {}
+func (m *ArrayValue) Reset()         { *m = ArrayValue{} }
+func (*ArrayValue) ProtoMessage()    {}
+func (m *ArrayValue) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *KeyValueList) Reset()      { *m = KeyValueList{} }
-func (*KeyValueList) ProtoMessage() {}
+func (m *KeyValueList) Reset()         { *m = KeyValueList{} }
+func (*KeyValueList) ProtoMessage()    {}
+func (m *KeyValueList) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *KeyValue) Reset()      { *m = KeyValue{} }
-func (*KeyValue) ProtoMessage() {}
+func (m *KeyValue) Reset()         { *m = KeyValue{} }
+func (*KeyValue) ProtoMessage()    {}
+func (m *KeyValue) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *InstrumentationScope) Reset()      { *m = InstrumentationScope{} }
-func (*InstrumentationScope) ProtoMessage() {}
+func (m *InstrumentationScope) Reset()         { *m = InstrumentationScope{} }
+func (*InstrumentationScope) ProtoMessage()    {}
+func (m *InstrumentationScope) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *EntityRef) Reset()      { *m = EntityRef{} }
-func (*EntityRef) ProtoMessage() {}
+func (m *EntityRef) Reset()         { *m = EntityRef{} }
+func (*EntityRef) ProtoMessage()    {}
+func (m *EntityRef) String() string { return fmt.Sprintf("%v", *m) }
 
 func (m *KeyValue) HasKey() bool {
 	return m.fieldsPresent[0]&(1<<0) != 0
@@ -2377,4 +2383,13 @@ func (this *EntityRef) Equal(that interface{}) bool {
 		}
 	}
 	return true
+}
+
+func init() {
+	protohelpers.RegisterType((*AnyValue)(nil), "opentelemetry.proto.common.v1.AnyValue")
+	protohelpers.RegisterType((*ArrayValue)(nil), "opentelemetry.proto.common.v1.ArrayValue")
+	protohelpers.RegisterType((*KeyValueList)(nil), "opentelemetry.proto.common.v1.KeyValueList")
+	protohelpers.RegisterType((*KeyValue)(nil), "opentelemetry.proto.common.v1.KeyValue")
+	protohelpers.RegisterType((*InstrumentationScope)(nil), "opentelemetry.proto.common.v1.InstrumentationScope")
+	protohelpers.RegisterType((*EntityRef)(nil), "opentelemetry.proto.common.v1.EntityRef")
 }

--- a/gen/otlp/common/v1/common.pb.go
+++ b/gen/otlp/common/v1/common.pb.go
@@ -175,59 +175,113 @@ type EntityRef struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *AnyValue) Reset()         { *m = AnyValue{} }
-func (*AnyValue) ProtoMessage()    {}
-func (m *AnyValue) String() string { return fmt.Sprintf("%v", *m) }
+func (m *AnyValue) Reset()      { *m = AnyValue{} }
+func (*AnyValue) ProtoMessage() {}
+func (m *AnyValue) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ArrayValue) Reset()         { *m = ArrayValue{} }
-func (*ArrayValue) ProtoMessage()    {}
-func (m *ArrayValue) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ArrayValue) Reset()      { *m = ArrayValue{} }
+func (*ArrayValue) ProtoMessage() {}
+func (m *ArrayValue) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *KeyValueList) Reset()         { *m = KeyValueList{} }
-func (*KeyValueList) ProtoMessage()    {}
-func (m *KeyValueList) String() string { return fmt.Sprintf("%v", *m) }
+func (m *KeyValueList) Reset()      { *m = KeyValueList{} }
+func (*KeyValueList) ProtoMessage() {}
+func (m *KeyValueList) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *KeyValue) Reset()         { *m = KeyValue{} }
-func (*KeyValue) ProtoMessage()    {}
-func (m *KeyValue) String() string { return fmt.Sprintf("%v", *m) }
+func (m *KeyValue) Reset()      { *m = KeyValue{} }
+func (*KeyValue) ProtoMessage() {}
+func (m *KeyValue) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *InstrumentationScope) Reset()         { *m = InstrumentationScope{} }
-func (*InstrumentationScope) ProtoMessage()    {}
-func (m *InstrumentationScope) String() string { return fmt.Sprintf("%v", *m) }
+func (m *InstrumentationScope) Reset()      { *m = InstrumentationScope{} }
+func (*InstrumentationScope) ProtoMessage() {}
+func (m *InstrumentationScope) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *EntityRef) Reset()         { *m = EntityRef{} }
-func (*EntityRef) ProtoMessage()    {}
-func (m *EntityRef) String() string { return fmt.Sprintf("%v", *m) }
+func (m *EntityRef) Reset()      { *m = EntityRef{} }
+func (*EntityRef) ProtoMessage() {}
+func (m *EntityRef) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
 func (m *KeyValue) HasKey() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *KeyValue) HasValue() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *KeyValue) HasKeyStrindex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *InstrumentationScope) HasName() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *InstrumentationScope) HasVersion() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *InstrumentationScope) HasDroppedAttributesCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *EntityRef) HasSchemaUrl() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *EntityRef) HasType() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 

--- a/gen/otlp/logs/v1/logs.pb.go
+++ b/gen/otlp/logs/v1/logs.pb.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
 	"io"
+	"strconv"
 	commonv1 "wiresmith/gen/otlp/common/v1"
 	resourcev1 "wiresmith/gen/otlp/resource/v1"
 	"wiresmith/gen/protohelpers"
@@ -45,6 +46,69 @@ const (
 	SEVERITY_NUMBER_FATAL4      SeverityNumber = 24
 )
 
+var SeverityNumber_name = map[int32]string{
+	0:  "SEVERITY_NUMBER_UNSPECIFIED",
+	1:  "SEVERITY_NUMBER_TRACE",
+	2:  "SEVERITY_NUMBER_TRACE2",
+	3:  "SEVERITY_NUMBER_TRACE3",
+	4:  "SEVERITY_NUMBER_TRACE4",
+	5:  "SEVERITY_NUMBER_DEBUG",
+	6:  "SEVERITY_NUMBER_DEBUG2",
+	7:  "SEVERITY_NUMBER_DEBUG3",
+	8:  "SEVERITY_NUMBER_DEBUG4",
+	9:  "SEVERITY_NUMBER_INFO",
+	10: "SEVERITY_NUMBER_INFO2",
+	11: "SEVERITY_NUMBER_INFO3",
+	12: "SEVERITY_NUMBER_INFO4",
+	13: "SEVERITY_NUMBER_WARN",
+	14: "SEVERITY_NUMBER_WARN2",
+	15: "SEVERITY_NUMBER_WARN3",
+	16: "SEVERITY_NUMBER_WARN4",
+	17: "SEVERITY_NUMBER_ERROR",
+	18: "SEVERITY_NUMBER_ERROR2",
+	19: "SEVERITY_NUMBER_ERROR3",
+	20: "SEVERITY_NUMBER_ERROR4",
+	21: "SEVERITY_NUMBER_FATAL",
+	22: "SEVERITY_NUMBER_FATAL2",
+	23: "SEVERITY_NUMBER_FATAL3",
+	24: "SEVERITY_NUMBER_FATAL4",
+}
+
+var SeverityNumber_value = map[string]int32{
+	"SEVERITY_NUMBER_UNSPECIFIED": 0,
+	"SEVERITY_NUMBER_TRACE":       1,
+	"SEVERITY_NUMBER_TRACE2":      2,
+	"SEVERITY_NUMBER_TRACE3":      3,
+	"SEVERITY_NUMBER_TRACE4":      4,
+	"SEVERITY_NUMBER_DEBUG":       5,
+	"SEVERITY_NUMBER_DEBUG2":      6,
+	"SEVERITY_NUMBER_DEBUG3":      7,
+	"SEVERITY_NUMBER_DEBUG4":      8,
+	"SEVERITY_NUMBER_INFO":        9,
+	"SEVERITY_NUMBER_INFO2":       10,
+	"SEVERITY_NUMBER_INFO3":       11,
+	"SEVERITY_NUMBER_INFO4":       12,
+	"SEVERITY_NUMBER_WARN":        13,
+	"SEVERITY_NUMBER_WARN2":       14,
+	"SEVERITY_NUMBER_WARN3":       15,
+	"SEVERITY_NUMBER_WARN4":       16,
+	"SEVERITY_NUMBER_ERROR":       17,
+	"SEVERITY_NUMBER_ERROR2":      18,
+	"SEVERITY_NUMBER_ERROR3":      19,
+	"SEVERITY_NUMBER_ERROR4":      20,
+	"SEVERITY_NUMBER_FATAL":       21,
+	"SEVERITY_NUMBER_FATAL2":      22,
+	"SEVERITY_NUMBER_FATAL3":      23,
+	"SEVERITY_NUMBER_FATAL4":      24,
+}
+
+func (x SeverityNumber) String() string {
+	if name, ok := SeverityNumber_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
+
 // LogRecordFlags represents constants used to interpret the
 // LogRecord.flags field, which is protobuf 'fixed32' type and is to
 // be used as bit-fields. Each non-zero value defined in this enum is
@@ -61,6 +125,23 @@ const (
 	// Bits 0-7 are used for trace flags.
 	LOG_RECORD_FLAGS_TRACE_FLAGS_MASK LogRecordFlags = 255
 )
+
+var LogRecordFlags_name = map[int32]string{
+	0:   "LOG_RECORD_FLAGS_DO_NOT_USE",
+	255: "LOG_RECORD_FLAGS_TRACE_FLAGS_MASK",
+}
+
+var LogRecordFlags_value = map[string]int32{
+	"LOG_RECORD_FLAGS_DO_NOT_USE":       0,
+	"LOG_RECORD_FLAGS_TRACE_FLAGS_MASK": 255,
+}
+
+func (x LogRecordFlags) String() string {
+	if name, ok := LogRecordFlags_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
 
 // LogsData represents the logs data that can be stored in a persistent storage,
 // OR can be embedded by other protocols that transfer OTLP logs data but do not
@@ -203,17 +284,21 @@ type LogRecord struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *LogsData) Reset()      { *m = LogsData{} }
-func (*LogsData) ProtoMessage() {}
+func (m *LogsData) Reset()         { *m = LogsData{} }
+func (*LogsData) ProtoMessage()    {}
+func (m *LogsData) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ResourceLogs) Reset()      { *m = ResourceLogs{} }
-func (*ResourceLogs) ProtoMessage() {}
+func (m *ResourceLogs) Reset()         { *m = ResourceLogs{} }
+func (*ResourceLogs) ProtoMessage()    {}
+func (m *ResourceLogs) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ScopeLogs) Reset()      { *m = ScopeLogs{} }
-func (*ScopeLogs) ProtoMessage() {}
+func (m *ScopeLogs) Reset()         { *m = ScopeLogs{} }
+func (*ScopeLogs) ProtoMessage()    {}
+func (m *ScopeLogs) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *LogRecord) Reset()      { *m = LogRecord{} }
-func (*LogRecord) ProtoMessage() {}
+func (m *LogRecord) Reset()         { *m = LogRecord{} }
+func (*LogRecord) ProtoMessage()    {}
+func (m *LogRecord) String() string { return fmt.Sprintf("%v", *m) }
 
 func (m *ResourceLogs) HasResource() bool {
 	return m.fieldsPresent[0]&(1<<0) != 0
@@ -2009,4 +2094,13 @@ func (this *LogRecord) Equal(that interface{}) bool {
 		return false
 	}
 	return true
+}
+
+func init() {
+	protohelpers.RegisterEnum("opentelemetry.proto.logs.v1.SeverityNumber", SeverityNumber_name, SeverityNumber_value)
+	protohelpers.RegisterEnum("opentelemetry.proto.logs.v1.LogRecordFlags", LogRecordFlags_name, LogRecordFlags_value)
+	protohelpers.RegisterType((*LogsData)(nil), "opentelemetry.proto.logs.v1.LogsData")
+	protohelpers.RegisterType((*ResourceLogs)(nil), "opentelemetry.proto.logs.v1.ResourceLogs")
+	protohelpers.RegisterType((*ScopeLogs)(nil), "opentelemetry.proto.logs.v1.ScopeLogs")
+	protohelpers.RegisterType((*LogRecord)(nil), "opentelemetry.proto.logs.v1.LogRecord")
 }

--- a/gen/otlp/logs/v1/logs.pb.go
+++ b/gen/otlp/logs/v1/logs.pb.go
@@ -284,75 +284,137 @@ type LogRecord struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *LogsData) Reset()         { *m = LogsData{} }
-func (*LogsData) ProtoMessage()    {}
-func (m *LogsData) String() string { return fmt.Sprintf("%v", *m) }
+func (m *LogsData) Reset()      { *m = LogsData{} }
+func (*LogsData) ProtoMessage() {}
+func (m *LogsData) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ResourceLogs) Reset()         { *m = ResourceLogs{} }
-func (*ResourceLogs) ProtoMessage()    {}
-func (m *ResourceLogs) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ResourceLogs) Reset()      { *m = ResourceLogs{} }
+func (*ResourceLogs) ProtoMessage() {}
+func (m *ResourceLogs) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ScopeLogs) Reset()         { *m = ScopeLogs{} }
-func (*ScopeLogs) ProtoMessage()    {}
-func (m *ScopeLogs) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ScopeLogs) Reset()      { *m = ScopeLogs{} }
+func (*ScopeLogs) ProtoMessage() {}
+func (m *ScopeLogs) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *LogRecord) Reset()         { *m = LogRecord{} }
-func (*LogRecord) ProtoMessage()    {}
-func (m *LogRecord) String() string { return fmt.Sprintf("%v", *m) }
+func (m *LogRecord) Reset()      { *m = LogRecord{} }
+func (*LogRecord) ProtoMessage() {}
+func (m *LogRecord) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
 func (m *ResourceLogs) HasResource() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ResourceLogs) HasSchemaUrl() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *ScopeLogs) HasScope() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ScopeLogs) HasSchemaUrl() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *LogRecord) HasTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *LogRecord) HasObservedTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *LogRecord) HasSeverityNumber() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *LogRecord) HasSeverityText() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *LogRecord) HasBody() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<4) != 0
 }
 
 func (m *LogRecord) HasDroppedAttributesCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<5) != 0
 }
 
 func (m *LogRecord) HasFlags() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<6) != 0
 }
 
 func (m *LogRecord) HasTraceId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<7) != 0
 }
 
 func (m *LogRecord) HasSpanId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<8) != 0
 }
 
 func (m *LogRecord) HasEventName() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<9) != 0
 }
 

--- a/gen/otlp/metrics/v1/metrics.pb.go
+++ b/gen/otlp/metrics/v1/metrics.pb.go
@@ -774,219 +774,413 @@ type Exemplar struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *MetricsData) Reset()         { *m = MetricsData{} }
-func (*MetricsData) ProtoMessage()    {}
-func (m *MetricsData) String() string { return fmt.Sprintf("%v", *m) }
+func (m *MetricsData) Reset()      { *m = MetricsData{} }
+func (*MetricsData) ProtoMessage() {}
+func (m *MetricsData) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ResourceMetrics) Reset()         { *m = ResourceMetrics{} }
-func (*ResourceMetrics) ProtoMessage()    {}
-func (m *ResourceMetrics) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ResourceMetrics) Reset()      { *m = ResourceMetrics{} }
+func (*ResourceMetrics) ProtoMessage() {}
+func (m *ResourceMetrics) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ScopeMetrics) Reset()         { *m = ScopeMetrics{} }
-func (*ScopeMetrics) ProtoMessage()    {}
-func (m *ScopeMetrics) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ScopeMetrics) Reset()      { *m = ScopeMetrics{} }
+func (*ScopeMetrics) ProtoMessage() {}
+func (m *ScopeMetrics) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Metric) Reset()         { *m = Metric{} }
-func (*Metric) ProtoMessage()    {}
-func (m *Metric) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Metric) Reset()      { *m = Metric{} }
+func (*Metric) ProtoMessage() {}
+func (m *Metric) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Gauge) Reset()         { *m = Gauge{} }
-func (*Gauge) ProtoMessage()    {}
-func (m *Gauge) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Gauge) Reset()      { *m = Gauge{} }
+func (*Gauge) ProtoMessage() {}
+func (m *Gauge) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Sum) Reset()         { *m = Sum{} }
-func (*Sum) ProtoMessage()    {}
-func (m *Sum) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Sum) Reset()      { *m = Sum{} }
+func (*Sum) ProtoMessage() {}
+func (m *Sum) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Histogram) Reset()         { *m = Histogram{} }
-func (*Histogram) ProtoMessage()    {}
-func (m *Histogram) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Histogram) Reset()      { *m = Histogram{} }
+func (*Histogram) ProtoMessage() {}
+func (m *Histogram) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ExponentialHistogram) Reset()         { *m = ExponentialHistogram{} }
-func (*ExponentialHistogram) ProtoMessage()    {}
-func (m *ExponentialHistogram) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ExponentialHistogram) Reset()      { *m = ExponentialHistogram{} }
+func (*ExponentialHistogram) ProtoMessage() {}
+func (m *ExponentialHistogram) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Summary) Reset()         { *m = Summary{} }
-func (*Summary) ProtoMessage()    {}
-func (m *Summary) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Summary) Reset()      { *m = Summary{} }
+func (*Summary) ProtoMessage() {}
+func (m *Summary) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *NumberDataPoint) Reset()         { *m = NumberDataPoint{} }
-func (*NumberDataPoint) ProtoMessage()    {}
-func (m *NumberDataPoint) String() string { return fmt.Sprintf("%v", *m) }
+func (m *NumberDataPoint) Reset()      { *m = NumberDataPoint{} }
+func (*NumberDataPoint) ProtoMessage() {}
+func (m *NumberDataPoint) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *HistogramDataPoint) Reset()         { *m = HistogramDataPoint{} }
-func (*HistogramDataPoint) ProtoMessage()    {}
-func (m *HistogramDataPoint) String() string { return fmt.Sprintf("%v", *m) }
+func (m *HistogramDataPoint) Reset()      { *m = HistogramDataPoint{} }
+func (*HistogramDataPoint) ProtoMessage() {}
+func (m *HistogramDataPoint) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ExponentialHistogramDataPoint_Buckets) Reset()         { *m = ExponentialHistogramDataPoint_Buckets{} }
-func (*ExponentialHistogramDataPoint_Buckets) ProtoMessage()    {}
-func (m *ExponentialHistogramDataPoint_Buckets) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ExponentialHistogramDataPoint_Buckets) Reset()      { *m = ExponentialHistogramDataPoint_Buckets{} }
+func (*ExponentialHistogramDataPoint_Buckets) ProtoMessage() {}
+func (m *ExponentialHistogramDataPoint_Buckets) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ExponentialHistogramDataPoint) Reset()         { *m = ExponentialHistogramDataPoint{} }
-func (*ExponentialHistogramDataPoint) ProtoMessage()    {}
-func (m *ExponentialHistogramDataPoint) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ExponentialHistogramDataPoint) Reset()      { *m = ExponentialHistogramDataPoint{} }
+func (*ExponentialHistogramDataPoint) ProtoMessage() {}
+func (m *ExponentialHistogramDataPoint) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *SummaryDataPoint_ValueAtQuantile) Reset()         { *m = SummaryDataPoint_ValueAtQuantile{} }
-func (*SummaryDataPoint_ValueAtQuantile) ProtoMessage()    {}
-func (m *SummaryDataPoint_ValueAtQuantile) String() string { return fmt.Sprintf("%v", *m) }
+func (m *SummaryDataPoint_ValueAtQuantile) Reset()      { *m = SummaryDataPoint_ValueAtQuantile{} }
+func (*SummaryDataPoint_ValueAtQuantile) ProtoMessage() {}
+func (m *SummaryDataPoint_ValueAtQuantile) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *SummaryDataPoint) Reset()         { *m = SummaryDataPoint{} }
-func (*SummaryDataPoint) ProtoMessage()    {}
-func (m *SummaryDataPoint) String() string { return fmt.Sprintf("%v", *m) }
+func (m *SummaryDataPoint) Reset()      { *m = SummaryDataPoint{} }
+func (*SummaryDataPoint) ProtoMessage() {}
+func (m *SummaryDataPoint) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Exemplar) Reset()         { *m = Exemplar{} }
-func (*Exemplar) ProtoMessage()    {}
-func (m *Exemplar) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Exemplar) Reset()      { *m = Exemplar{} }
+func (*Exemplar) ProtoMessage() {}
+func (m *Exemplar) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
 func (m *ResourceMetrics) HasResource() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ResourceMetrics) HasSchemaUrl() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *ScopeMetrics) HasScope() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ScopeMetrics) HasSchemaUrl() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Metric) HasName() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Metric) HasDescription() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Metric) HasUnit() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *Sum) HasAggregationTemporality() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Sum) HasIsMonotonic() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Histogram) HasAggregationTemporality() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ExponentialHistogram) HasAggregationTemporality() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *NumberDataPoint) HasStartTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *NumberDataPoint) HasTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *NumberDataPoint) HasFlags() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *HistogramDataPoint) HasStartTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *HistogramDataPoint) HasTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *HistogramDataPoint) HasCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *HistogramDataPoint) HasFlags() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *ExponentialHistogramDataPoint_Buckets) HasOffset() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ExponentialHistogramDataPoint) HasStartTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ExponentialHistogramDataPoint) HasTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *ExponentialHistogramDataPoint) HasCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *ExponentialHistogramDataPoint) HasScale() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *ExponentialHistogramDataPoint) HasZeroCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<4) != 0
 }
 
 func (m *ExponentialHistogramDataPoint) HasPositive() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<5) != 0
 }
 
 func (m *ExponentialHistogramDataPoint) HasNegative() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<6) != 0
 }
 
 func (m *ExponentialHistogramDataPoint) HasFlags() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<7) != 0
 }
 
 func (m *ExponentialHistogramDataPoint) HasZeroThreshold() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<8) != 0
 }
 
 func (m *SummaryDataPoint_ValueAtQuantile) HasQuantile() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *SummaryDataPoint_ValueAtQuantile) HasValue() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *SummaryDataPoint) HasStartTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *SummaryDataPoint) HasTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *SummaryDataPoint) HasCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *SummaryDataPoint) HasSum() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *SummaryDataPoint) HasFlags() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<4) != 0
 }
 
 func (m *Exemplar) HasTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Exemplar) HasSpanId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Exemplar) HasTraceId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 

--- a/gen/otlp/metrics/v1/metrics.pb.go
+++ b/gen/otlp/metrics/v1/metrics.pb.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 	"io"
 	"math"
+	"strconv"
 	commonv1 "wiresmith/gen/otlp/common/v1"
 	resourcev1 "wiresmith/gen/otlp/resource/v1"
 	"wiresmith/gen/protohelpers"
@@ -86,6 +87,25 @@ const (
 	AGGREGATION_TEMPORALITY_CUMULATIVE AggregationTemporality = 2
 )
 
+var AggregationTemporality_name = map[int32]string{
+	0: "AGGREGATION_TEMPORALITY_UNSPECIFIED",
+	1: "AGGREGATION_TEMPORALITY_DELTA",
+	2: "AGGREGATION_TEMPORALITY_CUMULATIVE",
+}
+
+var AggregationTemporality_value = map[string]int32{
+	"AGGREGATION_TEMPORALITY_UNSPECIFIED": 0,
+	"AGGREGATION_TEMPORALITY_DELTA":       1,
+	"AGGREGATION_TEMPORALITY_CUMULATIVE":  2,
+}
+
+func (x AggregationTemporality) String() string {
+	if name, ok := AggregationTemporality_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
+
 // DataPointFlags is defined as a protobuf 'uint32' type and is to be used as a
 // bit-field representing 32 distinct boolean flags.  Each flag defined in this
 // enum is a bit-mask.  To test the presence of a single flag in the flags of
@@ -103,6 +123,23 @@ const (
 	// for an equivalent to the Prometheus "staleness marker".
 	DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK DataPointFlags = 1
 )
+
+var DataPointFlags_name = map[int32]string{
+	0: "DATA_POINT_FLAGS_DO_NOT_USE",
+	1: "DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK",
+}
+
+var DataPointFlags_value = map[string]int32{
+	"DATA_POINT_FLAGS_DO_NOT_USE":             0,
+	"DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK": 1,
+}
+
+func (x DataPointFlags) String() string {
+	if name, ok := DataPointFlags_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
 
 type Metric_Data interface {
 	isMetric_Data()
@@ -737,53 +774,69 @@ type Exemplar struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *MetricsData) Reset()      { *m = MetricsData{} }
-func (*MetricsData) ProtoMessage() {}
+func (m *MetricsData) Reset()         { *m = MetricsData{} }
+func (*MetricsData) ProtoMessage()    {}
+func (m *MetricsData) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ResourceMetrics) Reset()      { *m = ResourceMetrics{} }
-func (*ResourceMetrics) ProtoMessage() {}
+func (m *ResourceMetrics) Reset()         { *m = ResourceMetrics{} }
+func (*ResourceMetrics) ProtoMessage()    {}
+func (m *ResourceMetrics) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ScopeMetrics) Reset()      { *m = ScopeMetrics{} }
-func (*ScopeMetrics) ProtoMessage() {}
+func (m *ScopeMetrics) Reset()         { *m = ScopeMetrics{} }
+func (*ScopeMetrics) ProtoMessage()    {}
+func (m *ScopeMetrics) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Metric) Reset()      { *m = Metric{} }
-func (*Metric) ProtoMessage() {}
+func (m *Metric) Reset()         { *m = Metric{} }
+func (*Metric) ProtoMessage()    {}
+func (m *Metric) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Gauge) Reset()      { *m = Gauge{} }
-func (*Gauge) ProtoMessage() {}
+func (m *Gauge) Reset()         { *m = Gauge{} }
+func (*Gauge) ProtoMessage()    {}
+func (m *Gauge) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Sum) Reset()      { *m = Sum{} }
-func (*Sum) ProtoMessage() {}
+func (m *Sum) Reset()         { *m = Sum{} }
+func (*Sum) ProtoMessage()    {}
+func (m *Sum) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Histogram) Reset()      { *m = Histogram{} }
-func (*Histogram) ProtoMessage() {}
+func (m *Histogram) Reset()         { *m = Histogram{} }
+func (*Histogram) ProtoMessage()    {}
+func (m *Histogram) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ExponentialHistogram) Reset()      { *m = ExponentialHistogram{} }
-func (*ExponentialHistogram) ProtoMessage() {}
+func (m *ExponentialHistogram) Reset()         { *m = ExponentialHistogram{} }
+func (*ExponentialHistogram) ProtoMessage()    {}
+func (m *ExponentialHistogram) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Summary) Reset()      { *m = Summary{} }
-func (*Summary) ProtoMessage() {}
+func (m *Summary) Reset()         { *m = Summary{} }
+func (*Summary) ProtoMessage()    {}
+func (m *Summary) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *NumberDataPoint) Reset()      { *m = NumberDataPoint{} }
-func (*NumberDataPoint) ProtoMessage() {}
+func (m *NumberDataPoint) Reset()         { *m = NumberDataPoint{} }
+func (*NumberDataPoint) ProtoMessage()    {}
+func (m *NumberDataPoint) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *HistogramDataPoint) Reset()      { *m = HistogramDataPoint{} }
-func (*HistogramDataPoint) ProtoMessage() {}
+func (m *HistogramDataPoint) Reset()         { *m = HistogramDataPoint{} }
+func (*HistogramDataPoint) ProtoMessage()    {}
+func (m *HistogramDataPoint) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ExponentialHistogramDataPoint_Buckets) Reset()      { *m = ExponentialHistogramDataPoint_Buckets{} }
-func (*ExponentialHistogramDataPoint_Buckets) ProtoMessage() {}
+func (m *ExponentialHistogramDataPoint_Buckets) Reset()         { *m = ExponentialHistogramDataPoint_Buckets{} }
+func (*ExponentialHistogramDataPoint_Buckets) ProtoMessage()    {}
+func (m *ExponentialHistogramDataPoint_Buckets) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ExponentialHistogramDataPoint) Reset()      { *m = ExponentialHistogramDataPoint{} }
-func (*ExponentialHistogramDataPoint) ProtoMessage() {}
+func (m *ExponentialHistogramDataPoint) Reset()         { *m = ExponentialHistogramDataPoint{} }
+func (*ExponentialHistogramDataPoint) ProtoMessage()    {}
+func (m *ExponentialHistogramDataPoint) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *SummaryDataPoint_ValueAtQuantile) Reset()      { *m = SummaryDataPoint_ValueAtQuantile{} }
-func (*SummaryDataPoint_ValueAtQuantile) ProtoMessage() {}
+func (m *SummaryDataPoint_ValueAtQuantile) Reset()         { *m = SummaryDataPoint_ValueAtQuantile{} }
+func (*SummaryDataPoint_ValueAtQuantile) ProtoMessage()    {}
+func (m *SummaryDataPoint_ValueAtQuantile) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *SummaryDataPoint) Reset()      { *m = SummaryDataPoint{} }
-func (*SummaryDataPoint) ProtoMessage() {}
+func (m *SummaryDataPoint) Reset()         { *m = SummaryDataPoint{} }
+func (*SummaryDataPoint) ProtoMessage()    {}
+func (m *SummaryDataPoint) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Exemplar) Reset()      { *m = Exemplar{} }
-func (*Exemplar) ProtoMessage() {}
+func (m *Exemplar) Reset()         { *m = Exemplar{} }
+func (*Exemplar) ProtoMessage()    {}
+func (m *Exemplar) String() string { return fmt.Sprintf("%v", *m) }
 
 func (m *ResourceMetrics) HasResource() bool {
 	return m.fieldsPresent[0]&(1<<0) != 0
@@ -7441,4 +7494,25 @@ func (this *Exemplar) Equal(that interface{}) bool {
 		return false
 	}
 	return true
+}
+
+func init() {
+	protohelpers.RegisterEnum("opentelemetry.proto.metrics.v1.AggregationTemporality", AggregationTemporality_name, AggregationTemporality_value)
+	protohelpers.RegisterEnum("opentelemetry.proto.metrics.v1.DataPointFlags", DataPointFlags_name, DataPointFlags_value)
+	protohelpers.RegisterType((*MetricsData)(nil), "opentelemetry.proto.metrics.v1.MetricsData")
+	protohelpers.RegisterType((*ResourceMetrics)(nil), "opentelemetry.proto.metrics.v1.ResourceMetrics")
+	protohelpers.RegisterType((*ScopeMetrics)(nil), "opentelemetry.proto.metrics.v1.ScopeMetrics")
+	protohelpers.RegisterType((*Metric)(nil), "opentelemetry.proto.metrics.v1.Metric")
+	protohelpers.RegisterType((*Gauge)(nil), "opentelemetry.proto.metrics.v1.Gauge")
+	protohelpers.RegisterType((*Sum)(nil), "opentelemetry.proto.metrics.v1.Sum")
+	protohelpers.RegisterType((*Histogram)(nil), "opentelemetry.proto.metrics.v1.Histogram")
+	protohelpers.RegisterType((*ExponentialHistogram)(nil), "opentelemetry.proto.metrics.v1.ExponentialHistogram")
+	protohelpers.RegisterType((*Summary)(nil), "opentelemetry.proto.metrics.v1.Summary")
+	protohelpers.RegisterType((*NumberDataPoint)(nil), "opentelemetry.proto.metrics.v1.NumberDataPoint")
+	protohelpers.RegisterType((*HistogramDataPoint)(nil), "opentelemetry.proto.metrics.v1.HistogramDataPoint")
+	protohelpers.RegisterType((*ExponentialHistogramDataPoint)(nil), "opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint")
+	protohelpers.RegisterType((*ExponentialHistogramDataPoint_Buckets)(nil), "opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint.Buckets")
+	protohelpers.RegisterType((*SummaryDataPoint)(nil), "opentelemetry.proto.metrics.v1.SummaryDataPoint")
+	protohelpers.RegisterType((*SummaryDataPoint_ValueAtQuantile)(nil), "opentelemetry.proto.metrics.v1.SummaryDataPoint.ValueAtQuantile")
+	protohelpers.RegisterType((*Exemplar)(nil), "opentelemetry.proto.metrics.v1.Exemplar")
 }

--- a/gen/otlp/profiles/v1development/profiles.pb.go
+++ b/gen/otlp/profiles/v1development/profiles.pb.go
@@ -414,203 +414,381 @@ type KeyValueAndUnit struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *ProfilesDictionary) Reset()         { *m = ProfilesDictionary{} }
-func (*ProfilesDictionary) ProtoMessage()    {}
-func (m *ProfilesDictionary) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ProfilesDictionary) Reset()      { *m = ProfilesDictionary{} }
+func (*ProfilesDictionary) ProtoMessage() {}
+func (m *ProfilesDictionary) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ProfilesData) Reset()         { *m = ProfilesData{} }
-func (*ProfilesData) ProtoMessage()    {}
-func (m *ProfilesData) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ProfilesData) Reset()      { *m = ProfilesData{} }
+func (*ProfilesData) ProtoMessage() {}
+func (m *ProfilesData) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ResourceProfiles) Reset()         { *m = ResourceProfiles{} }
-func (*ResourceProfiles) ProtoMessage()    {}
-func (m *ResourceProfiles) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ResourceProfiles) Reset()      { *m = ResourceProfiles{} }
+func (*ResourceProfiles) ProtoMessage() {}
+func (m *ResourceProfiles) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ScopeProfiles) Reset()         { *m = ScopeProfiles{} }
-func (*ScopeProfiles) ProtoMessage()    {}
-func (m *ScopeProfiles) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ScopeProfiles) Reset()      { *m = ScopeProfiles{} }
+func (*ScopeProfiles) ProtoMessage() {}
+func (m *ScopeProfiles) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Profile) Reset()         { *m = Profile{} }
-func (*Profile) ProtoMessage()    {}
-func (m *Profile) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Profile) Reset()      { *m = Profile{} }
+func (*Profile) ProtoMessage() {}
+func (m *Profile) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Link) Reset()         { *m = Link{} }
-func (*Link) ProtoMessage()    {}
-func (m *Link) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Link) Reset()      { *m = Link{} }
+func (*Link) ProtoMessage() {}
+func (m *Link) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ValueType) Reset()         { *m = ValueType{} }
-func (*ValueType) ProtoMessage()    {}
-func (m *ValueType) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ValueType) Reset()      { *m = ValueType{} }
+func (*ValueType) ProtoMessage() {}
+func (m *ValueType) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Sample) Reset()         { *m = Sample{} }
-func (*Sample) ProtoMessage()    {}
-func (m *Sample) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Sample) Reset()      { *m = Sample{} }
+func (*Sample) ProtoMessage() {}
+func (m *Sample) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Mapping) Reset()         { *m = Mapping{} }
-func (*Mapping) ProtoMessage()    {}
-func (m *Mapping) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Mapping) Reset()      { *m = Mapping{} }
+func (*Mapping) ProtoMessage() {}
+func (m *Mapping) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Stack) Reset()         { *m = Stack{} }
-func (*Stack) ProtoMessage()    {}
-func (m *Stack) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Stack) Reset()      { *m = Stack{} }
+func (*Stack) ProtoMessage() {}
+func (m *Stack) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Location) Reset()         { *m = Location{} }
-func (*Location) ProtoMessage()    {}
-func (m *Location) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Location) Reset()      { *m = Location{} }
+func (*Location) ProtoMessage() {}
+func (m *Location) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Line) Reset()         { *m = Line{} }
-func (*Line) ProtoMessage()    {}
-func (m *Line) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Line) Reset()      { *m = Line{} }
+func (*Line) ProtoMessage() {}
+func (m *Line) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Function) Reset()         { *m = Function{} }
-func (*Function) ProtoMessage()    {}
-func (m *Function) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Function) Reset()      { *m = Function{} }
+func (*Function) ProtoMessage() {}
+func (m *Function) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *KeyValueAndUnit) Reset()         { *m = KeyValueAndUnit{} }
-func (*KeyValueAndUnit) ProtoMessage()    {}
-func (m *KeyValueAndUnit) String() string { return fmt.Sprintf("%v", *m) }
+func (m *KeyValueAndUnit) Reset()      { *m = KeyValueAndUnit{} }
+func (*KeyValueAndUnit) ProtoMessage() {}
+func (m *KeyValueAndUnit) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
 func (m *ProfilesData) HasDictionary() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ResourceProfiles) HasResource() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ResourceProfiles) HasSchemaUrl() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *ScopeProfiles) HasScope() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ScopeProfiles) HasSchemaUrl() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Profile) HasSampleType() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Profile) HasTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Profile) HasDurationNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *Profile) HasPeriodType() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *Profile) HasPeriod() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<4) != 0
 }
 
 func (m *Profile) HasProfileId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<5) != 0
 }
 
 func (m *Profile) HasDroppedAttributesCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<6) != 0
 }
 
 func (m *Profile) HasOriginalPayloadFormat() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<7) != 0
 }
 
 func (m *Profile) HasOriginalPayload() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<8) != 0
 }
 
 func (m *Link) HasTraceId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Link) HasSpanId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *ValueType) HasTypeStrindex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ValueType) HasUnitStrindex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Sample) HasStackIndex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Sample) HasLinkIndex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Mapping) HasMemoryStart() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Mapping) HasMemoryLimit() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Mapping) HasFileOffset() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *Mapping) HasFilenameStrindex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *Location) HasMappingIndex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Location) HasAddress() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Line) HasFunctionIndex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Line) HasLine() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Line) HasColumn() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *Function) HasNameStrindex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Function) HasSystemNameStrindex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Function) HasFilenameStrindex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *Function) HasStartLine() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *KeyValueAndUnit) HasKeyStrindex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *KeyValueAndUnit) HasValue() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *KeyValueAndUnit) HasUnitStrindex() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 

--- a/gen/otlp/profiles/v1development/profiles.pb.go
+++ b/gen/otlp/profiles/v1development/profiles.pb.go
@@ -414,47 +414,61 @@ type KeyValueAndUnit struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *ProfilesDictionary) Reset()      { *m = ProfilesDictionary{} }
-func (*ProfilesDictionary) ProtoMessage() {}
+func (m *ProfilesDictionary) Reset()         { *m = ProfilesDictionary{} }
+func (*ProfilesDictionary) ProtoMessage()    {}
+func (m *ProfilesDictionary) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ProfilesData) Reset()      { *m = ProfilesData{} }
-func (*ProfilesData) ProtoMessage() {}
+func (m *ProfilesData) Reset()         { *m = ProfilesData{} }
+func (*ProfilesData) ProtoMessage()    {}
+func (m *ProfilesData) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ResourceProfiles) Reset()      { *m = ResourceProfiles{} }
-func (*ResourceProfiles) ProtoMessage() {}
+func (m *ResourceProfiles) Reset()         { *m = ResourceProfiles{} }
+func (*ResourceProfiles) ProtoMessage()    {}
+func (m *ResourceProfiles) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ScopeProfiles) Reset()      { *m = ScopeProfiles{} }
-func (*ScopeProfiles) ProtoMessage() {}
+func (m *ScopeProfiles) Reset()         { *m = ScopeProfiles{} }
+func (*ScopeProfiles) ProtoMessage()    {}
+func (m *ScopeProfiles) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Profile) Reset()      { *m = Profile{} }
-func (*Profile) ProtoMessage() {}
+func (m *Profile) Reset()         { *m = Profile{} }
+func (*Profile) ProtoMessage()    {}
+func (m *Profile) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Link) Reset()      { *m = Link{} }
-func (*Link) ProtoMessage() {}
+func (m *Link) Reset()         { *m = Link{} }
+func (*Link) ProtoMessage()    {}
+func (m *Link) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ValueType) Reset()      { *m = ValueType{} }
-func (*ValueType) ProtoMessage() {}
+func (m *ValueType) Reset()         { *m = ValueType{} }
+func (*ValueType) ProtoMessage()    {}
+func (m *ValueType) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Sample) Reset()      { *m = Sample{} }
-func (*Sample) ProtoMessage() {}
+func (m *Sample) Reset()         { *m = Sample{} }
+func (*Sample) ProtoMessage()    {}
+func (m *Sample) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Mapping) Reset()      { *m = Mapping{} }
-func (*Mapping) ProtoMessage() {}
+func (m *Mapping) Reset()         { *m = Mapping{} }
+func (*Mapping) ProtoMessage()    {}
+func (m *Mapping) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Stack) Reset()      { *m = Stack{} }
-func (*Stack) ProtoMessage() {}
+func (m *Stack) Reset()         { *m = Stack{} }
+func (*Stack) ProtoMessage()    {}
+func (m *Stack) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Location) Reset()      { *m = Location{} }
-func (*Location) ProtoMessage() {}
+func (m *Location) Reset()         { *m = Location{} }
+func (*Location) ProtoMessage()    {}
+func (m *Location) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Line) Reset()      { *m = Line{} }
-func (*Line) ProtoMessage() {}
+func (m *Line) Reset()         { *m = Line{} }
+func (*Line) ProtoMessage()    {}
+func (m *Line) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Function) Reset()      { *m = Function{} }
-func (*Function) ProtoMessage() {}
+func (m *Function) Reset()         { *m = Function{} }
+func (*Function) ProtoMessage()    {}
+func (m *Function) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *KeyValueAndUnit) Reset()      { *m = KeyValueAndUnit{} }
-func (*KeyValueAndUnit) ProtoMessage() {}
+func (m *KeyValueAndUnit) Reset()         { *m = KeyValueAndUnit{} }
+func (*KeyValueAndUnit) ProtoMessage()    {}
+func (m *KeyValueAndUnit) String() string { return fmt.Sprintf("%v", *m) }
 
 func (m *ProfilesData) HasDictionary() bool {
 	return m.fieldsPresent[0]&(1<<0) != 0
@@ -5770,4 +5784,21 @@ func (this *KeyValueAndUnit) Equal(that interface{}) bool {
 		return false
 	}
 	return true
+}
+
+func init() {
+	protohelpers.RegisterType((*ProfilesDictionary)(nil), "opentelemetry.proto.profiles.v1development.ProfilesDictionary")
+	protohelpers.RegisterType((*ProfilesData)(nil), "opentelemetry.proto.profiles.v1development.ProfilesData")
+	protohelpers.RegisterType((*ResourceProfiles)(nil), "opentelemetry.proto.profiles.v1development.ResourceProfiles")
+	protohelpers.RegisterType((*ScopeProfiles)(nil), "opentelemetry.proto.profiles.v1development.ScopeProfiles")
+	protohelpers.RegisterType((*Profile)(nil), "opentelemetry.proto.profiles.v1development.Profile")
+	protohelpers.RegisterType((*Link)(nil), "opentelemetry.proto.profiles.v1development.Link")
+	protohelpers.RegisterType((*ValueType)(nil), "opentelemetry.proto.profiles.v1development.ValueType")
+	protohelpers.RegisterType((*Sample)(nil), "opentelemetry.proto.profiles.v1development.Sample")
+	protohelpers.RegisterType((*Mapping)(nil), "opentelemetry.proto.profiles.v1development.Mapping")
+	protohelpers.RegisterType((*Stack)(nil), "opentelemetry.proto.profiles.v1development.Stack")
+	protohelpers.RegisterType((*Location)(nil), "opentelemetry.proto.profiles.v1development.Location")
+	protohelpers.RegisterType((*Line)(nil), "opentelemetry.proto.profiles.v1development.Line")
+	protohelpers.RegisterType((*Function)(nil), "opentelemetry.proto.profiles.v1development.Function")
+	protohelpers.RegisterType((*KeyValueAndUnit)(nil), "opentelemetry.proto.profiles.v1development.KeyValueAndUnit")
 }

--- a/gen/otlp/resource/v1/resource.pb.go
+++ b/gen/otlp/resource/v1/resource.pb.go
@@ -31,11 +31,19 @@ type Resource struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *Resource) Reset()         { *m = Resource{} }
-func (*Resource) ProtoMessage()    {}
-func (m *Resource) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Resource) Reset()      { *m = Resource{} }
+func (*Resource) ProtoMessage() {}
+func (m *Resource) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
 func (m *Resource) HasDroppedAttributesCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 

--- a/gen/otlp/resource/v1/resource.pb.go
+++ b/gen/otlp/resource/v1/resource.pb.go
@@ -31,8 +31,9 @@ type Resource struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *Resource) Reset()      { *m = Resource{} }
-func (*Resource) ProtoMessage() {}
+func (m *Resource) Reset()         { *m = Resource{} }
+func (*Resource) ProtoMessage()    {}
+func (m *Resource) String() string { return fmt.Sprintf("%v", *m) }
 
 func (m *Resource) HasDroppedAttributesCount() bool {
 	return m.fieldsPresent[0]&(1<<0) != 0
@@ -478,4 +479,8 @@ func (this *Resource) Equal(that interface{}) bool {
 		}
 	}
 	return true
+}
+
+func init() {
+	protohelpers.RegisterType((*Resource)(nil), "opentelemetry.proto.resource.v1.Resource")
 }

--- a/gen/otlp/trace/v1/trace.pb.go
+++ b/gen/otlp/trace/v1/trace.pb.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"google.golang.org/protobuf/encoding/protowire"
 	"io"
+	"strconv"
 	commonv1 "wiresmith/gen/otlp/common/v1"
 	resourcev1 "wiresmith/gen/otlp/resource/v1"
 	"wiresmith/gen/protohelpers"
@@ -43,6 +44,27 @@ const (
 	SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK     SpanFlags = 512
 )
 
+var SpanFlags_name = map[int32]string{
+	0:   "SPAN_FLAGS_DO_NOT_USE",
+	255: "SPAN_FLAGS_TRACE_FLAGS_MASK",
+	256: "SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK",
+	512: "SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK",
+}
+
+var SpanFlags_value = map[string]int32{
+	"SPAN_FLAGS_DO_NOT_USE":                 0,
+	"SPAN_FLAGS_TRACE_FLAGS_MASK":           255,
+	"SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK": 256,
+	"SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK":     512,
+}
+
+func (x SpanFlags) String() string {
+	if name, ok := SpanFlags_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
+
 // SpanKind is the type of span. Can be used to specify additional relationships between spans
 // in addition to a parent/child relationship.
 type Span_SpanKind int32
@@ -70,6 +92,31 @@ const (
 	SPAN_KIND_CONSUMER Span_SpanKind = 5
 )
 
+var Span_SpanKind_name = map[int32]string{
+	0: "SPAN_KIND_UNSPECIFIED",
+	1: "SPAN_KIND_INTERNAL",
+	2: "SPAN_KIND_SERVER",
+	3: "SPAN_KIND_CLIENT",
+	4: "SPAN_KIND_PRODUCER",
+	5: "SPAN_KIND_CONSUMER",
+}
+
+var Span_SpanKind_value = map[string]int32{
+	"SPAN_KIND_UNSPECIFIED": 0,
+	"SPAN_KIND_INTERNAL":    1,
+	"SPAN_KIND_SERVER":      2,
+	"SPAN_KIND_CLIENT":      3,
+	"SPAN_KIND_PRODUCER":    4,
+	"SPAN_KIND_CONSUMER":    5,
+}
+
+func (x Span_SpanKind) String() string {
+	if name, ok := Span_SpanKind_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
+
 // For the semantics of status codes see
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
 type Status_StatusCode int32
@@ -83,6 +130,25 @@ const (
 	// The Span contains an error.
 	STATUS_CODE_ERROR Status_StatusCode = 2
 )
+
+var Status_StatusCode_name = map[int32]string{
+	0: "STATUS_CODE_UNSET",
+	1: "STATUS_CODE_OK",
+	2: "STATUS_CODE_ERROR",
+}
+
+var Status_StatusCode_value = map[string]int32{
+	"STATUS_CODE_UNSET": 0,
+	"STATUS_CODE_OK":    1,
+	"STATUS_CODE_ERROR": 2,
+}
+
+func (x Status_StatusCode) String() string {
+	if name, ok := Status_StatusCode_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
 
 // TracesData represents the traces data that can be stored in a persistent storage,
 // OR can be embedded by other protocols that transfer OTLP traces data but do
@@ -324,26 +390,33 @@ type Status struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *TracesData) Reset()      { *m = TracesData{} }
-func (*TracesData) ProtoMessage() {}
+func (m *TracesData) Reset()         { *m = TracesData{} }
+func (*TracesData) ProtoMessage()    {}
+func (m *TracesData) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ResourceSpans) Reset()      { *m = ResourceSpans{} }
-func (*ResourceSpans) ProtoMessage() {}
+func (m *ResourceSpans) Reset()         { *m = ResourceSpans{} }
+func (*ResourceSpans) ProtoMessage()    {}
+func (m *ResourceSpans) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ScopeSpans) Reset()      { *m = ScopeSpans{} }
-func (*ScopeSpans) ProtoMessage() {}
+func (m *ScopeSpans) Reset()         { *m = ScopeSpans{} }
+func (*ScopeSpans) ProtoMessage()    {}
+func (m *ScopeSpans) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Span_Event) Reset()      { *m = Span_Event{} }
-func (*Span_Event) ProtoMessage() {}
+func (m *Span_Event) Reset()         { *m = Span_Event{} }
+func (*Span_Event) ProtoMessage()    {}
+func (m *Span_Event) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Span_Link) Reset()      { *m = Span_Link{} }
-func (*Span_Link) ProtoMessage() {}
+func (m *Span_Link) Reset()         { *m = Span_Link{} }
+func (*Span_Link) ProtoMessage()    {}
+func (m *Span_Link) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Span) Reset()      { *m = Span{} }
-func (*Span) ProtoMessage() {}
+func (m *Span) Reset()         { *m = Span{} }
+func (*Span) ProtoMessage()    {}
+func (m *Span) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Status) Reset()      { *m = Status{} }
-func (*Status) ProtoMessage() {}
+func (m *Status) Reset()         { *m = Status{} }
+func (*Status) ProtoMessage()    {}
+func (m *Status) String() string { return fmt.Sprintf("%v", *m) }
 
 func (m *ResourceSpans) HasResource() bool {
 	return m.fieldsPresent[0]&(1<<0) != 0
@@ -3525,4 +3598,17 @@ func (this *Status) Equal(that interface{}) bool {
 		return false
 	}
 	return true
+}
+
+func init() {
+	protohelpers.RegisterEnum("opentelemetry.proto.trace.v1.SpanFlags", SpanFlags_name, SpanFlags_value)
+	protohelpers.RegisterEnum("opentelemetry.proto.trace.v1.Span.SpanKind", Span_SpanKind_name, Span_SpanKind_value)
+	protohelpers.RegisterEnum("opentelemetry.proto.trace.v1.Status.StatusCode", Status_StatusCode_name, Status_StatusCode_value)
+	protohelpers.RegisterType((*TracesData)(nil), "opentelemetry.proto.trace.v1.TracesData")
+	protohelpers.RegisterType((*ResourceSpans)(nil), "opentelemetry.proto.trace.v1.ResourceSpans")
+	protohelpers.RegisterType((*ScopeSpans)(nil), "opentelemetry.proto.trace.v1.ScopeSpans")
+	protohelpers.RegisterType((*Span)(nil), "opentelemetry.proto.trace.v1.Span")
+	protohelpers.RegisterType((*Span_Event)(nil), "opentelemetry.proto.trace.v1.Span.Event")
+	protohelpers.RegisterType((*Span_Link)(nil), "opentelemetry.proto.trace.v1.Span.Link")
+	protohelpers.RegisterType((*Status)(nil), "opentelemetry.proto.trace.v1.Status")
 }

--- a/gen/otlp/trace/v1/trace.pb.go
+++ b/gen/otlp/trace/v1/trace.pb.go
@@ -390,139 +390,255 @@ type Status struct {
 	fieldsPresent [1]uint64
 }
 
-func (m *TracesData) Reset()         { *m = TracesData{} }
-func (*TracesData) ProtoMessage()    {}
-func (m *TracesData) String() string { return fmt.Sprintf("%v", *m) }
+func (m *TracesData) Reset()      { *m = TracesData{} }
+func (*TracesData) ProtoMessage() {}
+func (m *TracesData) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ResourceSpans) Reset()         { *m = ResourceSpans{} }
-func (*ResourceSpans) ProtoMessage()    {}
-func (m *ResourceSpans) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ResourceSpans) Reset()      { *m = ResourceSpans{} }
+func (*ResourceSpans) ProtoMessage() {}
+func (m *ResourceSpans) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ScopeSpans) Reset()         { *m = ScopeSpans{} }
-func (*ScopeSpans) ProtoMessage()    {}
-func (m *ScopeSpans) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ScopeSpans) Reset()      { *m = ScopeSpans{} }
+func (*ScopeSpans) ProtoMessage() {}
+func (m *ScopeSpans) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Span_Event) Reset()         { *m = Span_Event{} }
-func (*Span_Event) ProtoMessage()    {}
-func (m *Span_Event) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Span_Event) Reset()      { *m = Span_Event{} }
+func (*Span_Event) ProtoMessage() {}
+func (m *Span_Event) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Span_Link) Reset()         { *m = Span_Link{} }
-func (*Span_Link) ProtoMessage()    {}
-func (m *Span_Link) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Span_Link) Reset()      { *m = Span_Link{} }
+func (*Span_Link) ProtoMessage() {}
+func (m *Span_Link) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Span) Reset()         { *m = Span{} }
-func (*Span) ProtoMessage()    {}
-func (m *Span) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Span) Reset()      { *m = Span{} }
+func (*Span) ProtoMessage() {}
+func (m *Span) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Status) Reset()         { *m = Status{} }
-func (*Status) ProtoMessage()    {}
-func (m *Status) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Status) Reset()      { *m = Status{} }
+func (*Status) ProtoMessage() {}
+func (m *Status) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
 func (m *ResourceSpans) HasResource() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ResourceSpans) HasSchemaUrl() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *ScopeSpans) HasScope() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *ScopeSpans) HasSchemaUrl() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Span_Event) HasTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Span_Event) HasName() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Span_Event) HasDroppedAttributesCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *Span_Link) HasTraceId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Span_Link) HasSpanId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Span_Link) HasTraceState() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *Span_Link) HasDroppedAttributesCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *Span_Link) HasFlags() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<4) != 0
 }
 
 func (m *Span) HasTraceId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Span) HasSpanId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Span) HasTraceState() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *Span) HasParentSpanId() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *Span) HasFlags() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<4) != 0
 }
 
 func (m *Span) HasName() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<5) != 0
 }
 
 func (m *Span) HasKind() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<6) != 0
 }
 
 func (m *Span) HasStartTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<7) != 0
 }
 
 func (m *Span) HasEndTimeUnixNano() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<8) != 0
 }
 
 func (m *Span) HasDroppedAttributesCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<9) != 0
 }
 
 func (m *Span) HasDroppedEventsCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<10) != 0
 }
 
 func (m *Span) HasDroppedLinksCount() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<11) != 0
 }
 
 func (m *Span) HasStatus() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<12) != 0
 }
 
 func (m *Status) HasMessage() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Status) HasCode() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 

--- a/gen/protobuf_test_messages/proto3/test_messages_proto3.pb.go
+++ b/gen/protobuf_test_messages/proto3/test_messages_proto3.pb.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math"
 	"slices"
+	"strconv"
 	"wiresmith/gen/protohelpers"
 )
 
@@ -22,6 +23,25 @@ const (
 	FOREIGN_BAZ ForeignEnum = 2
 )
 
+var ForeignEnum_name = map[int32]string{
+	0: "FOREIGN_FOO",
+	1: "FOREIGN_BAR",
+	2: "FOREIGN_BAZ",
+}
+
+var ForeignEnum_value = map[string]int32{
+	"FOREIGN_FOO": 0,
+	"FOREIGN_BAR": 1,
+	"FOREIGN_BAZ": 2,
+}
+
+func (x ForeignEnum) String() string {
+	if name, ok := ForeignEnum_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
+
 type TestAllTypesProto3_NestedEnum int32
 
 const (
@@ -31,12 +51,50 @@ const (
 	NEG TestAllTypesProto3_NestedEnum = -1
 )
 
+var TestAllTypesProto3_NestedEnum_name = map[int32]string{
+	0:  "FOO",
+	1:  "BAR",
+	2:  "BAZ",
+	-1: "NEG",
+}
+
+var TestAllTypesProto3_NestedEnum_value = map[string]int32{
+	"FOO": 0,
+	"BAR": 1,
+	"BAZ": 2,
+	"NEG": -1,
+}
+
+func (x TestAllTypesProto3_NestedEnum) String() string {
+	if name, ok := TestAllTypesProto3_NestedEnum_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
+
 type EnumOnlyProto3_Bool int32
 
 const (
 	kFalse EnumOnlyProto3_Bool = 0
 	kTrue  EnumOnlyProto3_Bool = 1
 )
+
+var EnumOnlyProto3_Bool_name = map[int32]string{
+	0: "kFalse",
+	1: "kTrue",
+}
+
+var EnumOnlyProto3_Bool_value = map[string]int32{
+	"kFalse": 0,
+	"kTrue":  1,
+}
+
+func (x EnumOnlyProto3_Bool) String() string {
+	if name, ok := EnumOnlyProto3_Bool_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
 
 type TestAllTypesProto3_OneofField interface {
 	isTestAllTypesProto3_OneofField()
@@ -238,20 +296,25 @@ type NullHypothesisProto3 struct {
 type EnumOnlyProto3 struct {
 }
 
-func (m *TestAllTypesProto3_NestedMessage) Reset()      { *m = TestAllTypesProto3_NestedMessage{} }
-func (*TestAllTypesProto3_NestedMessage) ProtoMessage() {}
+func (m *TestAllTypesProto3_NestedMessage) Reset()         { *m = TestAllTypesProto3_NestedMessage{} }
+func (*TestAllTypesProto3_NestedMessage) ProtoMessage()    {}
+func (m *TestAllTypesProto3_NestedMessage) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *TestAllTypesProto3) Reset()      { *m = TestAllTypesProto3{} }
-func (*TestAllTypesProto3) ProtoMessage() {}
+func (m *TestAllTypesProto3) Reset()         { *m = TestAllTypesProto3{} }
+func (*TestAllTypesProto3) ProtoMessage()    {}
+func (m *TestAllTypesProto3) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *ForeignMessage) Reset()      { *m = ForeignMessage{} }
-func (*ForeignMessage) ProtoMessage() {}
+func (m *ForeignMessage) Reset()         { *m = ForeignMessage{} }
+func (*ForeignMessage) ProtoMessage()    {}
+func (m *ForeignMessage) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *NullHypothesisProto3) Reset()      { *m = NullHypothesisProto3{} }
-func (*NullHypothesisProto3) ProtoMessage() {}
+func (m *NullHypothesisProto3) Reset()         { *m = NullHypothesisProto3{} }
+func (*NullHypothesisProto3) ProtoMessage()    {}
+func (m *NullHypothesisProto3) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *EnumOnlyProto3) Reset()      { *m = EnumOnlyProto3{} }
-func (*EnumOnlyProto3) ProtoMessage() {}
+func (m *EnumOnlyProto3) Reset()         { *m = EnumOnlyProto3{} }
+func (*EnumOnlyProto3) ProtoMessage()    {}
+func (m *EnumOnlyProto3) String() string { return fmt.Sprintf("%v", *m) }
 
 func (m *TestAllTypesProto3_NestedMessage) HasA() bool {
 	return m.fieldsPresent[0]&(1<<0) != 0
@@ -10497,4 +10560,15 @@ func (this *EnumOnlyProto3) Equal(that interface{}) bool {
 		return false
 	}
 	return true
+}
+
+func init() {
+	protohelpers.RegisterEnum("protobuf_test_messages.proto3.ForeignEnum", ForeignEnum_name, ForeignEnum_value)
+	protohelpers.RegisterEnum("protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum", TestAllTypesProto3_NestedEnum_name, TestAllTypesProto3_NestedEnum_value)
+	protohelpers.RegisterEnum("protobuf_test_messages.proto3.EnumOnlyProto3.Bool", EnumOnlyProto3_Bool_name, EnumOnlyProto3_Bool_value)
+	protohelpers.RegisterType((*TestAllTypesProto3)(nil), "protobuf_test_messages.proto3.TestAllTypesProto3")
+	protohelpers.RegisterType((*TestAllTypesProto3_NestedMessage)(nil), "protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage")
+	protohelpers.RegisterType((*ForeignMessage)(nil), "protobuf_test_messages.proto3.ForeignMessage")
+	protohelpers.RegisterType((*NullHypothesisProto3)(nil), "protobuf_test_messages.proto3.NullHypothesisProto3")
+	protohelpers.RegisterType((*EnumOnlyProto3)(nil), "protobuf_test_messages.proto3.EnumOnlyProto3")
 }

--- a/gen/protobuf_test_messages/proto3/test_messages_proto3.pb.go
+++ b/gen/protobuf_test_messages/proto3/test_messages_proto3.pb.go
@@ -296,187 +296,335 @@ type NullHypothesisProto3 struct {
 type EnumOnlyProto3 struct {
 }
 
-func (m *TestAllTypesProto3_NestedMessage) Reset()         { *m = TestAllTypesProto3_NestedMessage{} }
-func (*TestAllTypesProto3_NestedMessage) ProtoMessage()    {}
-func (m *TestAllTypesProto3_NestedMessage) String() string { return fmt.Sprintf("%v", *m) }
+func (m *TestAllTypesProto3_NestedMessage) Reset()      { *m = TestAllTypesProto3_NestedMessage{} }
+func (*TestAllTypesProto3_NestedMessage) ProtoMessage() {}
+func (m *TestAllTypesProto3_NestedMessage) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *TestAllTypesProto3) Reset()         { *m = TestAllTypesProto3{} }
-func (*TestAllTypesProto3) ProtoMessage()    {}
-func (m *TestAllTypesProto3) String() string { return fmt.Sprintf("%v", *m) }
+func (m *TestAllTypesProto3) Reset()      { *m = TestAllTypesProto3{} }
+func (*TestAllTypesProto3) ProtoMessage() {}
+func (m *TestAllTypesProto3) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *ForeignMessage) Reset()         { *m = ForeignMessage{} }
-func (*ForeignMessage) ProtoMessage()    {}
-func (m *ForeignMessage) String() string { return fmt.Sprintf("%v", *m) }
+func (m *ForeignMessage) Reset()      { *m = ForeignMessage{} }
+func (*ForeignMessage) ProtoMessage() {}
+func (m *ForeignMessage) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *NullHypothesisProto3) Reset()         { *m = NullHypothesisProto3{} }
-func (*NullHypothesisProto3) ProtoMessage()    {}
-func (m *NullHypothesisProto3) String() string { return fmt.Sprintf("%v", *m) }
+func (m *NullHypothesisProto3) Reset()      { *m = NullHypothesisProto3{} }
+func (*NullHypothesisProto3) ProtoMessage() {}
+func (m *NullHypothesisProto3) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *EnumOnlyProto3) Reset()         { *m = EnumOnlyProto3{} }
-func (*EnumOnlyProto3) ProtoMessage()    {}
-func (m *EnumOnlyProto3) String() string { return fmt.Sprintf("%v", *m) }
+func (m *EnumOnlyProto3) Reset()      { *m = EnumOnlyProto3{} }
+func (*EnumOnlyProto3) ProtoMessage() {}
+func (m *EnumOnlyProto3) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
 func (m *TestAllTypesProto3_NestedMessage) HasA() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalInt32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalInt64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalUint32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalUint64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalSint32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<4) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalSint64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<5) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalFixed32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<6) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalFixed64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<7) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalSfixed32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<8) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalSfixed64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<9) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalFloat() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<10) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalDouble() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<11) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalBool() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<12) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalString() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<13) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalBytes() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<14) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalNestedMessage() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<15) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalForeignMessage() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<16) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalNestedEnum() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<17) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalForeignEnum() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<18) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalStringPiece() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<19) != 0
 }
 
 func (m *TestAllTypesProto3) HasOptionalCord() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<20) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldname1() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<21) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName2() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<22) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName3() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<23) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName4() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<24) != 0
 }
 
 func (m *TestAllTypesProto3) HasField0name5() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<25) != 0
 }
 
 func (m *TestAllTypesProto3) HasField0Name6() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<26) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName7() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<27) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName8() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<28) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName9() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<29) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName10() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<30) != 0
 }
 
 func (m *TestAllTypesProto3) HasFIELDNAME11() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<31) != 0
 }
 
 func (m *TestAllTypesProto3) HasFIELDName12() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<32) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName13() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<33) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName14() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<34) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName15() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<35) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName16() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<36) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName17() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<37) != 0
 }
 
 func (m *TestAllTypesProto3) HasFieldName18() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<38) != 0
 }
 
 func (m *ForeignMessage) HasC() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 

--- a/gen/protohelpers/registry.go
+++ b/gen/protohelpers/registry.go
@@ -1,7 +1,6 @@
 package protohelpers
 
 import (
-	"maps"
 	"reflect"
 )
 
@@ -35,12 +34,8 @@ func MessageType(fullName string) reflect.Type {
 	return messageTypes[fullName]
 }
 
-// EnumValueMap returns a copy of the string→int32 map for a registered enum,
+// EnumValueMap returns the string→int32 map for a registered enum name,
 // or nil if not registered.
 func EnumValueMap(fullName string) map[string]int32 {
-	m := enumValues[fullName]
-	if m == nil {
-		return nil
-	}
-	return maps.Clone(m)
+	return enumValues[fullName]
 }

--- a/gen/protohelpers/registry.go
+++ b/gen/protohelpers/registry.go
@@ -10,6 +10,9 @@ var enumValues = map[string]map[string]int32{}
 // Called from generated init() functions.
 func RegisterType(msg any, fullName string) {
 	t := reflect.TypeOf(msg)
+	if t == nil {
+		panic("protohelpers.RegisterType: msg must not be nil")
+	}
 	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}

--- a/gen/protohelpers/registry.go
+++ b/gen/protohelpers/registry.go
@@ -1,0 +1,36 @@
+package protohelpers
+
+import "reflect"
+
+var messageTypes = map[string]reflect.Type{}
+var enumNames = map[string]map[int32]string{}
+var enumValues = map[string]map[string]int32{}
+
+// RegisterType records a message type by its full proto name.
+// Called from generated init() functions.
+func RegisterType(msg any, fullName string) {
+	t := reflect.TypeOf(msg)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	messageTypes[fullName] = t
+}
+
+// RegisterEnum records enum name/value maps by the enum's full proto name.
+// Called from generated init() functions.
+func RegisterEnum(fullName string, names map[int32]string, values map[string]int32) {
+	enumNames[fullName] = names
+	enumValues[fullName] = values
+}
+
+// MessageType returns the reflect.Type for a registered proto message name,
+// or nil if not registered.
+func MessageType(fullName string) reflect.Type {
+	return messageTypes[fullName]
+}
+
+// EnumValueMap returns the string→int32 map for a registered enum name,
+// or nil if not registered.
+func EnumValueMap(fullName string) map[string]int32 {
+	return enumValues[fullName]
+}

--- a/gen/protohelpers/registry.go
+++ b/gen/protohelpers/registry.go
@@ -1,13 +1,16 @@
 package protohelpers
 
-import "reflect"
+import (
+	"maps"
+	"reflect"
+)
 
 var messageTypes = map[string]reflect.Type{}
 var enumNames = map[string]map[int32]string{}
 var enumValues = map[string]map[string]int32{}
 
 // RegisterType records a message type by its full proto name.
-// Called from generated init() functions.
+// Called from generated init() functions; not safe for concurrent use.
 func RegisterType(msg any, fullName string) {
 	t := reflect.TypeOf(msg)
 	if t == nil {
@@ -20,7 +23,7 @@ func RegisterType(msg any, fullName string) {
 }
 
 // RegisterEnum records enum name/value maps by the enum's full proto name.
-// Called from generated init() functions.
+// Called from generated init() functions; not safe for concurrent use.
 func RegisterEnum(fullName string, names map[int32]string, values map[string]int32) {
 	enumNames[fullName] = names
 	enumValues[fullName] = values
@@ -32,8 +35,12 @@ func MessageType(fullName string) reflect.Type {
 	return messageTypes[fullName]
 }
 
-// EnumValueMap returns the string→int32 map for a registered enum name,
+// EnumValueMap returns a copy of the string→int32 map for a registered enum,
 // or nil if not registered.
 func EnumValueMap(fullName string) map[string]int32 {
-	return enumValues[fullName]
+	m := enumValues[fullName]
+	if m == nil {
+		return nil
+	}
+	return maps.Clone(m)
 }

--- a/gen/test/kitchensink/v1/kitchen_sink.pb.go
+++ b/gen/test/kitchensink/v1/kitchen_sink.pb.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math"
 	"slices"
+	"strconv"
 	"wiresmith/gen/protohelpers"
 )
 
@@ -23,6 +24,27 @@ const (
 	COLOR_GREEN       Color = 2
 	COLOR_BLUE        Color = 3
 )
+
+var Color_name = map[int32]string{
+	0: "COLOR_UNSPECIFIED",
+	1: "COLOR_RED",
+	2: "COLOR_GREEN",
+	3: "COLOR_BLUE",
+}
+
+var Color_value = map[string]int32{
+	"COLOR_UNSPECIFIED": 0,
+	"COLOR_RED":         1,
+	"COLOR_GREEN":       2,
+	"COLOR_BLUE":        3,
+}
+
+func (x Color) String() string {
+	if name, ok := Color_name[int32(x)]; ok {
+		return name
+	}
+	return strconv.FormatInt(int64(x), 10)
+}
 
 type OneofVariants_Value interface {
 	isOneofVariants_Value()
@@ -267,44 +289,57 @@ type AllMaps struct {
 	MapStringEnum       map[string]Color
 }
 
-func (m *AllScalars) Reset()      { *m = AllScalars{} }
-func (*AllScalars) ProtoMessage() {}
+func (m *AllScalars) Reset()         { *m = AllScalars{} }
+func (*AllScalars) ProtoMessage()    {}
+func (m *AllScalars) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *AllOptionalScalars) Reset()      { *m = AllOptionalScalars{} }
-func (*AllOptionalScalars) ProtoMessage() {}
+func (m *AllOptionalScalars) Reset()         { *m = AllOptionalScalars{} }
+func (*AllOptionalScalars) ProtoMessage()    {}
+func (m *AllOptionalScalars) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *AllRepeatedScalars) Reset()      { *m = AllRepeatedScalars{} }
-func (*AllRepeatedScalars) ProtoMessage() {}
+func (m *AllRepeatedScalars) Reset()         { *m = AllRepeatedScalars{} }
+func (*AllRepeatedScalars) ProtoMessage()    {}
+func (m *AllRepeatedScalars) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *OneofVariants) Reset()      { *m = OneofVariants{} }
-func (*OneofVariants) ProtoMessage() {}
+func (m *OneofVariants) Reset()         { *m = OneofVariants{} }
+func (*OneofVariants) ProtoMessage()    {}
+func (m *OneofVariants) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Outer) Reset()      { *m = Outer{} }
-func (*Outer) ProtoMessage() {}
+func (m *Outer) Reset()         { *m = Outer{} }
+func (*Outer) ProtoMessage()    {}
+func (m *Outer) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Middle) Reset()      { *m = Middle{} }
-func (*Middle) ProtoMessage() {}
+func (m *Middle) Reset()         { *m = Middle{} }
+func (*Middle) ProtoMessage()    {}
+func (m *Middle) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Inner) Reset()      { *m = Inner{} }
-func (*Inner) ProtoMessage() {}
+func (m *Inner) Reset()         { *m = Inner{} }
+func (*Inner) ProtoMessage()    {}
+func (m *Inner) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *HighFieldNumbers) Reset()      { *m = HighFieldNumbers{} }
-func (*HighFieldNumbers) ProtoMessage() {}
+func (m *HighFieldNumbers) Reset()         { *m = HighFieldNumbers{} }
+func (*HighFieldNumbers) ProtoMessage()    {}
+func (m *HighFieldNumbers) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *WithEnum) Reset()      { *m = WithEnum{} }
-func (*WithEnum) ProtoMessage() {}
+func (m *WithEnum) Reset()         { *m = WithEnum{} }
+func (*WithEnum) ProtoMessage()    {}
+func (m *WithEnum) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Empty) Reset()      { *m = Empty{} }
-func (*Empty) ProtoMessage() {}
+func (m *Empty) Reset()         { *m = Empty{} }
+func (*Empty) ProtoMessage()    {}
+func (m *Empty) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *OnlyRepeated) Reset()      { *m = OnlyRepeated{} }
-func (*OnlyRepeated) ProtoMessage() {}
+func (m *OnlyRepeated) Reset()         { *m = OnlyRepeated{} }
+func (*OnlyRepeated) ProtoMessage()    {}
+func (m *OnlyRepeated) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *Container) Reset()      { *m = Container{} }
-func (*Container) ProtoMessage() {}
+func (m *Container) Reset()         { *m = Container{} }
+func (*Container) ProtoMessage()    {}
+func (m *Container) String() string { return fmt.Sprintf("%v", *m) }
 
-func (m *AllMaps) Reset()      { *m = AllMaps{} }
-func (*AllMaps) ProtoMessage() {}
+func (m *AllMaps) Reset()         { *m = AllMaps{} }
+func (*AllMaps) ProtoMessage()    {}
+func (m *AllMaps) String() string { return fmt.Sprintf("%v", *m) }
 
 func (m *AllScalars) HasFieldDouble() bool {
 	return m.fieldsPresent[0]&(1<<0) != 0
@@ -9251,4 +9286,21 @@ func (this *AllMaps) Equal(that interface{}) bool {
 		}
 	}
 	return true
+}
+
+func init() {
+	protohelpers.RegisterEnum("test.kitchensink.v1.Color", Color_name, Color_value)
+	protohelpers.RegisterType((*AllScalars)(nil), "test.kitchensink.v1.AllScalars")
+	protohelpers.RegisterType((*AllOptionalScalars)(nil), "test.kitchensink.v1.AllOptionalScalars")
+	protohelpers.RegisterType((*AllRepeatedScalars)(nil), "test.kitchensink.v1.AllRepeatedScalars")
+	protohelpers.RegisterType((*OneofVariants)(nil), "test.kitchensink.v1.OneofVariants")
+	protohelpers.RegisterType((*Outer)(nil), "test.kitchensink.v1.Outer")
+	protohelpers.RegisterType((*Middle)(nil), "test.kitchensink.v1.Middle")
+	protohelpers.RegisterType((*Inner)(nil), "test.kitchensink.v1.Inner")
+	protohelpers.RegisterType((*HighFieldNumbers)(nil), "test.kitchensink.v1.HighFieldNumbers")
+	protohelpers.RegisterType((*WithEnum)(nil), "test.kitchensink.v1.WithEnum")
+	protohelpers.RegisterType((*Empty)(nil), "test.kitchensink.v1.Empty")
+	protohelpers.RegisterType((*OnlyRepeated)(nil), "test.kitchensink.v1.OnlyRepeated")
+	protohelpers.RegisterType((*Container)(nil), "test.kitchensink.v1.Container")
+	protohelpers.RegisterType((*AllMaps)(nil), "test.kitchensink.v1.AllMaps")
 }

--- a/gen/test/kitchensink/v1/kitchen_sink.pb.go
+++ b/gen/test/kitchensink/v1/kitchen_sink.pb.go
@@ -289,179 +289,337 @@ type AllMaps struct {
 	MapStringEnum       map[string]Color
 }
 
-func (m *AllScalars) Reset()         { *m = AllScalars{} }
-func (*AllScalars) ProtoMessage()    {}
-func (m *AllScalars) String() string { return fmt.Sprintf("%v", *m) }
+func (m *AllScalars) Reset()      { *m = AllScalars{} }
+func (*AllScalars) ProtoMessage() {}
+func (m *AllScalars) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *AllOptionalScalars) Reset()         { *m = AllOptionalScalars{} }
-func (*AllOptionalScalars) ProtoMessage()    {}
-func (m *AllOptionalScalars) String() string { return fmt.Sprintf("%v", *m) }
+func (m *AllOptionalScalars) Reset()      { *m = AllOptionalScalars{} }
+func (*AllOptionalScalars) ProtoMessage() {}
+func (m *AllOptionalScalars) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *AllRepeatedScalars) Reset()         { *m = AllRepeatedScalars{} }
-func (*AllRepeatedScalars) ProtoMessage()    {}
-func (m *AllRepeatedScalars) String() string { return fmt.Sprintf("%v", *m) }
+func (m *AllRepeatedScalars) Reset()      { *m = AllRepeatedScalars{} }
+func (*AllRepeatedScalars) ProtoMessage() {}
+func (m *AllRepeatedScalars) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *OneofVariants) Reset()         { *m = OneofVariants{} }
-func (*OneofVariants) ProtoMessage()    {}
-func (m *OneofVariants) String() string { return fmt.Sprintf("%v", *m) }
+func (m *OneofVariants) Reset()      { *m = OneofVariants{} }
+func (*OneofVariants) ProtoMessage() {}
+func (m *OneofVariants) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Outer) Reset()         { *m = Outer{} }
-func (*Outer) ProtoMessage()    {}
-func (m *Outer) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Outer) Reset()      { *m = Outer{} }
+func (*Outer) ProtoMessage() {}
+func (m *Outer) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Middle) Reset()         { *m = Middle{} }
-func (*Middle) ProtoMessage()    {}
-func (m *Middle) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Middle) Reset()      { *m = Middle{} }
+func (*Middle) ProtoMessage() {}
+func (m *Middle) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Inner) Reset()         { *m = Inner{} }
-func (*Inner) ProtoMessage()    {}
-func (m *Inner) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Inner) Reset()      { *m = Inner{} }
+func (*Inner) ProtoMessage() {}
+func (m *Inner) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *HighFieldNumbers) Reset()         { *m = HighFieldNumbers{} }
-func (*HighFieldNumbers) ProtoMessage()    {}
-func (m *HighFieldNumbers) String() string { return fmt.Sprintf("%v", *m) }
+func (m *HighFieldNumbers) Reset()      { *m = HighFieldNumbers{} }
+func (*HighFieldNumbers) ProtoMessage() {}
+func (m *HighFieldNumbers) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *WithEnum) Reset()         { *m = WithEnum{} }
-func (*WithEnum) ProtoMessage()    {}
-func (m *WithEnum) String() string { return fmt.Sprintf("%v", *m) }
+func (m *WithEnum) Reset()      { *m = WithEnum{} }
+func (*WithEnum) ProtoMessage() {}
+func (m *WithEnum) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Empty) Reset()         { *m = Empty{} }
-func (*Empty) ProtoMessage()    {}
-func (m *Empty) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Empty) Reset()      { *m = Empty{} }
+func (*Empty) ProtoMessage() {}
+func (m *Empty) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *OnlyRepeated) Reset()         { *m = OnlyRepeated{} }
-func (*OnlyRepeated) ProtoMessage()    {}
-func (m *OnlyRepeated) String() string { return fmt.Sprintf("%v", *m) }
+func (m *OnlyRepeated) Reset()      { *m = OnlyRepeated{} }
+func (*OnlyRepeated) ProtoMessage() {}
+func (m *OnlyRepeated) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *Container) Reset()         { *m = Container{} }
-func (*Container) ProtoMessage()    {}
-func (m *Container) String() string { return fmt.Sprintf("%v", *m) }
+func (m *Container) Reset()      { *m = Container{} }
+func (*Container) ProtoMessage() {}
+func (m *Container) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
-func (m *AllMaps) Reset()         { *m = AllMaps{} }
-func (*AllMaps) ProtoMessage()    {}
-func (m *AllMaps) String() string { return fmt.Sprintf("%v", *m) }
+func (m *AllMaps) Reset()      { *m = AllMaps{} }
+func (*AllMaps) ProtoMessage() {}
+func (m *AllMaps) String() string {
+	if m == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", *m)
+}
 
 func (m *AllScalars) HasFieldDouble() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *AllScalars) HasFieldFloat() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *AllScalars) HasFieldInt32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *AllScalars) HasFieldInt64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *AllScalars) HasFieldUint32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<4) != 0
 }
 
 func (m *AllScalars) HasFieldUint64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<5) != 0
 }
 
 func (m *AllScalars) HasFieldSint32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<6) != 0
 }
 
 func (m *AllScalars) HasFieldSint64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<7) != 0
 }
 
 func (m *AllScalars) HasFieldFixed32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<8) != 0
 }
 
 func (m *AllScalars) HasFieldFixed64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<9) != 0
 }
 
 func (m *AllScalars) HasFieldSfixed32() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<10) != 0
 }
 
 func (m *AllScalars) HasFieldSfixed64() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<11) != 0
 }
 
 func (m *AllScalars) HasFieldBool() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<12) != 0
 }
 
 func (m *AllScalars) HasFieldString() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<13) != 0
 }
 
 func (m *AllScalars) HasFieldBytes() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<14) != 0
 }
 
 func (m *Outer) HasMiddle() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Outer) HasName() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Middle) HasInner() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Middle) HasValue() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Inner) HasData() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Inner) HasRaw() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *Inner) HasSignedVal() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *Inner) HasFixedVal() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *HighFieldNumbers) HasField1() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *HighFieldNumbers) HasField16() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 
 func (m *HighFieldNumbers) HasField128() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<2) != 0
 }
 
 func (m *HighFieldNumbers) HasField2048() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<3) != 0
 }
 
 func (m *HighFieldNumbers) HasField16384() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<4) != 0
 }
 
 func (m *WithEnum) HasColor() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Container) HasVariant() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<0) != 0
 }
 
 func (m *Container) HasScalars() bool {
+	if m == nil {
+		return false
+	}
 	return m.fieldsPresent[0]&(1<<1) != 0
 }
 


### PR DESCRIPTION
## Summary

- **`.pb.go` file suffix**: Generated files now use the standard `.pb.go` convention (matching protoc-gen-go, vtproto, gogoproto)
- **`String()` on messages**: All messages get `String() string` using `fmt.Sprintf("%v", *m)` — completes the `proto.Message` interface shape
- **Enum name/value maps + `String()`**: Each enum gets `TypeName_name` (int32→string), `TypeName_value` (string→int32), and a `String()` method matching gogoproto's bare-name convention
- **Type registration**: Generated `init()` registers all messages and enums via a lightweight self-hosted registry in `gen/protohelpers/registry.go` — no gogo/protobuf dependency

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./test/ ./compiler/...` passes (correctness + codegen smoke test)
- [x] `go vet` clean on changed packages
- [x] `make conformance` passes (Docker-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)