### PR TITLE
refactor: extract forEachMessage and presence bitmap helpers

### DIFF
--- a/compiler/generator/emit_equal.go
+++ b/compiler/generator/emit_equal.go
@@ -7,20 +7,7 @@ import (
 )
 
 func (fg *FileGenerator) emitAllEqualMethods(fd protoreflect.FileDescriptor) {
-	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitEqualMethods(fd.Messages().Get(i))
-	}
-}
-
-func (fg *FileGenerator) emitEqualMethods(md protoreflect.MessageDescriptor) {
-	for i := 0; i < md.Messages().Len(); i++ {
-		nested := md.Messages().Get(i)
-		if nested.IsMapEntry() {
-			continue
-		}
-		fg.emitEqualMethods(nested)
-	}
-	fg.emitEqual(md)
+	forEachMessage(fd, fg.emitEqual)
 }
 
 func (fg *FileGenerator) emitEqual(md protoreflect.MessageDescriptor) {

--- a/compiler/generator/emit_getter.go
+++ b/compiler/generator/emit_getter.go
@@ -7,20 +7,7 @@ import (
 )
 
 func (fg *FileGenerator) emitAllGetterMethods(fd protoreflect.FileDescriptor) {
-	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitGetterMethods(fd.Messages().Get(i))
-	}
-}
-
-func (fg *FileGenerator) emitGetterMethods(md protoreflect.MessageDescriptor) {
-	for i := 0; i < md.Messages().Len(); i++ {
-		nested := md.Messages().Get(i)
-		if nested.IsMapEntry() {
-			continue
-		}
-		fg.emitGetterMethods(nested)
-	}
-	fg.emitGetters(md)
+	forEachMessage(fd, fg.emitGetters)
 }
 
 func (fg *FileGenerator) emitGetters(md protoreflect.MessageDescriptor) {
@@ -74,7 +61,7 @@ func (fg *FileGenerator) emitGetters(md protoreflect.MessageDescriptor) {
 			bitIndex, hasBit := pm[fd.Number()]
 			fmt.Fprintf(fg.body, "func (m *%s) Get%s() *%s {\n", name, goName, msgType)
 			if hasBit {
-				fmt.Fprintf(fg.body, "\tif m != nil && m.fieldsPresent[%d]&(1<<%d) != 0 {\n", bitIndex/64, bitIndex%64)
+				fmt.Fprintf(fg.body, "\tif m != nil && %s {\n", presenceCheck(bitIndex))
 			} else {
 				// Defensive: emitted when the field has no presence-bitmap entry.
 				fmt.Fprintf(fg.body, "\tif m != nil {\n")

--- a/compiler/generator/emit_has.go
+++ b/compiler/generator/emit_has.go
@@ -51,15 +51,25 @@ func presenceMap(md protoreflect.MessageDescriptor) map[protoreflect.FieldNumber
 	return m
 }
 
+// presenceCheck returns the Go expression "m.fieldsPresent[W]&(1<<B) != 0"
+// for the given bit index.
+func presenceCheck(bitIndex int) string {
+	return fmt.Sprintf("m.fieldsPresent[%d]&(1<<%d) != 0", bitIndex/64, bitIndex%64)
+}
+
+// presenceSet returns the Go statement "m.fieldsPresent[W] |= 1 << B"
+// for the given bit index.
+func presenceSet(bitIndex int) string {
+	return fmt.Sprintf("m.fieldsPresent[%d] |= 1 << %d", bitIndex/64, bitIndex%64)
+}
+
 func (fg *FileGenerator) emitHasMethods(md protoreflect.MessageDescriptor) {
 	name := goMessageTypeName(md)
 	for _, pf := range fieldsForPresence(md) {
 		goName := snakeToPascal(string(pf.fd.Name()))
-		wordIndex := pf.bitIndex / 64
-		bitOffset := pf.bitIndex % 64
 		fmt.Fprintf(fg.body, "func (m *%s) Has%s() bool {\n", name, goName)
 		fmt.Fprintf(fg.body, "\tif m == nil {\n\t\treturn false\n\t}\n")
-		fmt.Fprintf(fg.body, "\treturn m.fieldsPresent[%d]&(1<<%d) != 0\n", wordIndex, bitOffset)
+		fmt.Fprintf(fg.body, "\treturn %s\n", presenceCheck(pf.bitIndex))
 		fmt.Fprintf(fg.body, "}\n\n")
 	}
 }

--- a/compiler/generator/emit_marshal.go
+++ b/compiler/generator/emit_marshal.go
@@ -95,8 +95,6 @@ func (fg *FileGenerator) emitMessageMarshalWithPresence(fd protoreflect.FieldDes
 	goName := snakeToPascal(string(fd.Name()))
 	access := "m." + goName
 	num := protowire.Number(fd.Number())
-	wordIndex := bitIndex / 64
-	bitOffset := bitIndex % 64
 
 	fg.imports.addImport(fg.module+"/gen/protohelpers", "")
 	fmt.Fprintf(fg.body, "\t{\n")
@@ -106,7 +104,7 @@ func (fg *FileGenerator) emitMessageMarshalWithPresence(fd protoreflect.FieldDes
 	fmt.Fprintf(fg.body, "\t\t\ti -= size\n")
 	fmt.Fprintf(fg.body, "\t\t\ti = protohelpers.EncodeVarint(dAtA, i, uint64(size))\n")
 	fg.reverseTag("\t\t\t", num, protowire.BytesType)
-	fmt.Fprintf(fg.body, "\t\t} else if m.fieldsPresent[%d]&(1<<%d) != 0 {\n", wordIndex, bitOffset)
+	fmt.Fprintf(fg.body, "\t\t} else if %s {\n", presenceCheck(bitIndex))
 	fmt.Fprintf(fg.body, "\t\t\ti--\n")
 	fmt.Fprintf(fg.body, "\t\t\tdAtA[i] = 0\n")
 	fg.reverseTag("\t\t\t", num, protowire.BytesType)

--- a/compiler/generator/emit_registration.go
+++ b/compiler/generator/emit_registration.go
@@ -8,61 +8,28 @@ import (
 
 func (fg *FileGenerator) emitRegistration(fd protoreflect.FileDescriptor) {
 	fg.body.WriteString("func init() {\n")
-	fg.emitEnumRegistrations(fd)
-	fg.emitMessageRegistrations(fd)
-	fg.body.WriteString("}\n")
 
-	fg.imports.addImport(fg.module+"/gen/protohelpers", "")
-}
-
-func (fg *FileGenerator) emitEnumRegistrations(parent protoreflect.Descriptor) {
-	var enums protoreflect.EnumDescriptors
-	switch p := parent.(type) {
-	case protoreflect.FileDescriptor:
-		enums = p.Enums()
-	case protoreflect.MessageDescriptor:
-		enums = p.Enums()
-	}
-	for i := 0; i < enums.Len(); i++ {
-		ed := enums.Get(i)
-		typeName := goEnumTypeName(ed)
-		fmt.Fprintf(fg.body, "\tprotohelpers.RegisterEnum(%q, %s_name, %s_value)\n",
-			ed.FullName(), typeName, typeName)
+	// File-level enums.
+	for i := 0; i < fd.Enums().Len(); i++ {
+		fg.emitEnumRegistration(fd.Enums().Get(i))
 	}
 
-	// Recurse into nested messages
-	var msgs protoreflect.MessageDescriptors
-	switch p := parent.(type) {
-	case protoreflect.FileDescriptor:
-		msgs = p.Messages()
-	case protoreflect.MessageDescriptor:
-		msgs = p.Messages()
-	}
-	for i := 0; i < msgs.Len(); i++ {
-		md := msgs.Get(i)
-		if md.IsMapEntry() {
-			continue
-		}
-		fg.emitEnumRegistrations(md)
-	}
-}
-
-func (fg *FileGenerator) emitMessageRegistrations(parent protoreflect.Descriptor) {
-	var msgs protoreflect.MessageDescriptors
-	switch p := parent.(type) {
-	case protoreflect.FileDescriptor:
-		msgs = p.Messages()
-	case protoreflect.MessageDescriptor:
-		msgs = p.Messages()
-	}
-	for i := 0; i < msgs.Len(); i++ {
-		md := msgs.Get(i)
-		if md.IsMapEntry() {
-			continue
+	// Per-message enums and message registration.
+	forEachMessage(fd, func(md protoreflect.MessageDescriptor) {
+		for i := 0; i < md.Enums().Len(); i++ {
+			fg.emitEnumRegistration(md.Enums().Get(i))
 		}
 		typeName := goMessageTypeName(md)
 		fmt.Fprintf(fg.body, "\tprotohelpers.RegisterType((*%s)(nil), %q)\n",
 			typeName, md.FullName())
-		fg.emitMessageRegistrations(md)
-	}
+	})
+
+	fg.body.WriteString("}\n")
+	fg.imports.addImport(fg.module+"/gen/protohelpers", "")
+}
+
+func (fg *FileGenerator) emitEnumRegistration(ed protoreflect.EnumDescriptor) {
+	typeName := goEnumTypeName(ed)
+	fmt.Fprintf(fg.body, "\tprotohelpers.RegisterEnum(%q, %s_name, %s_value)\n",
+		ed.FullName(), typeName, typeName)
 }

--- a/compiler/generator/emit_reset.go
+++ b/compiler/generator/emit_reset.go
@@ -7,20 +7,7 @@ import (
 )
 
 func (fg *FileGenerator) emitAllResetMethods(fd protoreflect.FileDescriptor) {
-	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitResetMethods(fd.Messages().Get(i))
-	}
-}
-
-func (fg *FileGenerator) emitResetMethods(md protoreflect.MessageDescriptor) {
-	for i := 0; i < md.Messages().Len(); i++ {
-		nested := md.Messages().Get(i)
-		if nested.IsMapEntry() {
-			continue
-		}
-		fg.emitResetMethods(nested)
-	}
-	fg.emitReset(md)
+	forEachMessage(fd, fg.emitReset)
 }
 
 func (fg *FileGenerator) emitReset(md protoreflect.MessageDescriptor) {

--- a/compiler/generator/emit_size.go
+++ b/compiler/generator/emit_size.go
@@ -48,12 +48,10 @@ func (fg *FileGenerator) emitMessageSizeWithPresence(fd protoreflect.FieldDescri
 	goName := snakeToPascal(string(fd.Name()))
 	access := "m." + goName
 	tagSize := protowire.SizeTag(protowire.Number(fd.Number()))
-	wordIndex := bitIndex / 64
-	bitOffset := bitIndex % 64
 
 	fmt.Fprintf(fg.body, "\t{\n\t\ts := %s.Size()\n", access)
 	fmt.Fprintf(fg.body, "\t\tif s > 0 {\n\t\t\tn += %d + protowire.SizeVarint(uint64(s)) + s\n\t\t}", tagSize)
-	fmt.Fprintf(fg.body, " else if m.fieldsPresent[%d]&(1<<%d) != 0 {\n\t\t\tn += %d\n\t\t}\n", wordIndex, bitOffset, tagSize+1)
+	fmt.Fprintf(fg.body, " else if %s {\n\t\t\tn += %d\n\t\t}\n", presenceCheck(bitIndex), tagSize+1)
 	fmt.Fprintf(fg.body, "\t}\n")
 }
 

--- a/compiler/generator/emit_unmarshal.go
+++ b/compiler/generator/emit_unmarshal.go
@@ -190,7 +190,7 @@ func (fg *FileGenerator) emitUnmarshal(md protoreflect.MessageDescriptor) {
 		fd := md.Fields().Get(i)
 		fg.emitFieldUnmarshal(md, fd)
 		if bitIndex, ok := pm[fd.Number()]; ok {
-			fmt.Fprintf(fg.body, "\t\t\tm.fieldsPresent[%d] |= 1 << %d\n", bitIndex/64, bitIndex%64)
+			fmt.Fprintf(fg.body, "\t\t\t%s\n", presenceSet(bitIndex))
 		}
 	}
 

--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -209,8 +209,9 @@ func (fg *FileGenerator) emitAllUnmarshalMethods(fd protoreflect.FileDescriptor)
 	forEachMessage(fd, fg.emitUnmarshal)
 }
 
-// forEachMessage calls fn for every non-map-entry message reachable from fd,
-// visiting nested messages before their parent (post-order).
+// forEachMessage calls fn for every message reachable from fd, skipping
+// nested map-entry messages and visiting nested messages before their
+// parent (post-order).
 func forEachMessage(fd protoreflect.FileDescriptor, fn func(protoreflect.MessageDescriptor)) {
 	for i := 0; i < fd.Messages().Len(); i++ {
 		walkMessages(fd.Messages().Get(i), fn)

--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -167,133 +167,65 @@ func (fg *FileGenerator) emitAllEnums(fd protoreflect.FileDescriptor) {
 	for i := 0; i < fd.Enums().Len(); i++ {
 		fg.emitEnum(fd.Enums().Get(i))
 	}
-	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitNestedEnums(fd.Messages().Get(i))
-	}
-}
-
-func (fg *FileGenerator) emitNestedEnums(md protoreflect.MessageDescriptor) {
-	for i := 0; i < md.Enums().Len(); i++ {
-		fg.emitEnum(md.Enums().Get(i))
-	}
-	for i := 0; i < md.Messages().Len(); i++ {
-		nested := md.Messages().Get(i)
-		if nested.IsMapEntry() {
-			continue
+	forEachMessage(fd, func(md protoreflect.MessageDescriptor) {
+		for i := 0; i < md.Enums().Len(); i++ {
+			fg.emitEnum(md.Enums().Get(i))
 		}
-		fg.emitNestedEnums(nested)
-	}
+	})
 }
 
 func (fg *FileGenerator) emitAllOneofs(fd protoreflect.FileDescriptor) {
-	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitMessageOneofs(fd.Messages().Get(i))
-	}
-}
-
-func (fg *FileGenerator) emitMessageOneofs(md protoreflect.MessageDescriptor) {
-	for i := 0; i < md.Oneofs().Len(); i++ {
-		oo := md.Oneofs().Get(i)
-		if oo.IsSynthetic() {
-			continue
+	forEachMessage(fd, func(md protoreflect.MessageDescriptor) {
+		for i := 0; i < md.Oneofs().Len(); i++ {
+			oo := md.Oneofs().Get(i)
+			if oo.IsSynthetic() {
+				continue
+			}
+			fg.emitOneof(md, oo)
 		}
-		fg.emitOneof(md, oo)
-	}
-	for i := 0; i < md.Messages().Len(); i++ {
-		nested := md.Messages().Get(i)
-		if nested.IsMapEntry() {
-			continue
-		}
-		fg.emitMessageOneofs(nested)
-	}
+	})
 }
 
 func (fg *FileGenerator) emitAllStructs(fd protoreflect.FileDescriptor) {
-	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitMessageStructs(fd.Messages().Get(i))
-	}
-}
-
-func (fg *FileGenerator) emitMessageStructs(md protoreflect.MessageDescriptor) {
-	for i := 0; i < md.Messages().Len(); i++ {
-		nested := md.Messages().Get(i)
-		if nested.IsMapEntry() {
-			continue
-		}
-		fg.emitMessageStructs(nested)
-	}
-	fg.emitStruct(md)
+	forEachMessage(fd, fg.emitStruct)
 }
 
 func (fg *FileGenerator) emitAllHasMethods(fd protoreflect.FileDescriptor) {
-	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitHasMethodsRecursive(fd.Messages().Get(i))
-	}
-}
-
-func (fg *FileGenerator) emitHasMethodsRecursive(md protoreflect.MessageDescriptor) {
-	for i := 0; i < md.Messages().Len(); i++ {
-		nested := md.Messages().Get(i)
-		if nested.IsMapEntry() {
-			continue
-		}
-		fg.emitHasMethodsRecursive(nested)
-	}
-	fg.emitHasMethods(md)
+	forEachMessage(fd, fg.emitHasMethods)
 }
 
 func (fg *FileGenerator) emitAllSizeMethods(fd protoreflect.FileDescriptor) {
-	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitSizeMethods(fd.Messages().Get(i))
-	}
-}
-
-func (fg *FileGenerator) emitSizeMethods(md protoreflect.MessageDescriptor) {
-	for i := 0; i < md.Messages().Len(); i++ {
-		nested := md.Messages().Get(i)
-		if nested.IsMapEntry() {
-			continue
-		}
-		fg.emitSizeMethods(nested)
-	}
-	fg.emitSize(md)
+	forEachMessage(fd, fg.emitSize)
 }
 
 func (fg *FileGenerator) emitAllMarshalMethods(fd protoreflect.FileDescriptor) {
-	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitMarshalMethods(fd.Messages().Get(i))
-	}
-}
-
-func (fg *FileGenerator) emitMarshalMethods(md protoreflect.MessageDescriptor) {
-	for i := 0; i < md.Messages().Len(); i++ {
-		nested := md.Messages().Get(i)
-		if nested.IsMapEntry() {
-			continue
-		}
-		fg.emitMarshalMethods(nested)
-	}
-	fg.emitMarshal(md)
+	forEachMessage(fd, fg.emitMarshal)
 }
 
 func (fg *FileGenerator) emitAllUnmarshalMethods(fd protoreflect.FileDescriptor) {
 	// Emit the max recursion depth constant and skip helpers once per file.
 	fmt.Fprintf(fg.body, "const maxUnmarshalDepth = 10000\n\n")
 	fg.emitSkipValueHelper()
+	forEachMessage(fd, fg.emitUnmarshal)
+}
+
+// forEachMessage calls fn for every non-map-entry message reachable from fd,
+// visiting nested messages before their parent (post-order).
+func forEachMessage(fd protoreflect.FileDescriptor, fn func(protoreflect.MessageDescriptor)) {
 	for i := 0; i < fd.Messages().Len(); i++ {
-		fg.emitUnmarshalMethods(fd.Messages().Get(i))
+		walkMessages(fd.Messages().Get(i), fn)
 	}
 }
 
-func (fg *FileGenerator) emitUnmarshalMethods(md protoreflect.MessageDescriptor) {
+func walkMessages(md protoreflect.MessageDescriptor, fn func(protoreflect.MessageDescriptor)) {
 	for i := 0; i < md.Messages().Len(); i++ {
 		nested := md.Messages().Get(i)
 		if nested.IsMapEntry() {
 			continue
 		}
-		fg.emitUnmarshalMethods(nested)
+		walkMessages(nested, fn)
 	}
-	fg.emitUnmarshal(md)
+	fn(md)
 }
 
 // isRealOneof returns true if the field belongs to a non-synthetic oneof.

--- a/gen/otlp/metrics/v1/metrics.pb.go
+++ b/gen/otlp/metrics/v1/metrics.pb.go
@@ -7712,9 +7712,9 @@ func init() {
 	protohelpers.RegisterType((*Summary)(nil), "opentelemetry.proto.metrics.v1.Summary")
 	protohelpers.RegisterType((*NumberDataPoint)(nil), "opentelemetry.proto.metrics.v1.NumberDataPoint")
 	protohelpers.RegisterType((*HistogramDataPoint)(nil), "opentelemetry.proto.metrics.v1.HistogramDataPoint")
-	protohelpers.RegisterType((*ExponentialHistogramDataPoint)(nil), "opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint")
 	protohelpers.RegisterType((*ExponentialHistogramDataPoint_Buckets)(nil), "opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint.Buckets")
-	protohelpers.RegisterType((*SummaryDataPoint)(nil), "opentelemetry.proto.metrics.v1.SummaryDataPoint")
+	protohelpers.RegisterType((*ExponentialHistogramDataPoint)(nil), "opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint")
 	protohelpers.RegisterType((*SummaryDataPoint_ValueAtQuantile)(nil), "opentelemetry.proto.metrics.v1.SummaryDataPoint.ValueAtQuantile")
+	protohelpers.RegisterType((*SummaryDataPoint)(nil), "opentelemetry.proto.metrics.v1.SummaryDataPoint")
 	protohelpers.RegisterType((*Exemplar)(nil), "opentelemetry.proto.metrics.v1.Exemplar")
 }

--- a/gen/otlp/trace/v1/trace.pb.go
+++ b/gen/otlp/trace/v1/trace.pb.go
@@ -3704,13 +3704,13 @@ func (this *Status) Equal(that interface{}) bool {
 
 func init() {
 	protohelpers.RegisterEnum("opentelemetry.proto.trace.v1.SpanFlags", SpanFlags_name, SpanFlags_value)
-	protohelpers.RegisterEnum("opentelemetry.proto.trace.v1.Span.SpanKind", Span_SpanKind_name, Span_SpanKind_value)
-	protohelpers.RegisterEnum("opentelemetry.proto.trace.v1.Status.StatusCode", Status_StatusCode_name, Status_StatusCode_value)
 	protohelpers.RegisterType((*TracesData)(nil), "opentelemetry.proto.trace.v1.TracesData")
 	protohelpers.RegisterType((*ResourceSpans)(nil), "opentelemetry.proto.trace.v1.ResourceSpans")
 	protohelpers.RegisterType((*ScopeSpans)(nil), "opentelemetry.proto.trace.v1.ScopeSpans")
-	protohelpers.RegisterType((*Span)(nil), "opentelemetry.proto.trace.v1.Span")
 	protohelpers.RegisterType((*Span_Event)(nil), "opentelemetry.proto.trace.v1.Span.Event")
 	protohelpers.RegisterType((*Span_Link)(nil), "opentelemetry.proto.trace.v1.Span.Link")
+	protohelpers.RegisterEnum("opentelemetry.proto.trace.v1.Span.SpanKind", Span_SpanKind_name, Span_SpanKind_value)
+	protohelpers.RegisterType((*Span)(nil), "opentelemetry.proto.trace.v1.Span")
+	protohelpers.RegisterEnum("opentelemetry.proto.trace.v1.Status.StatusCode", Status_StatusCode_name, Status_StatusCode_value)
 	protohelpers.RegisterType((*Status)(nil), "opentelemetry.proto.trace.v1.Status")
 }

--- a/gen/protobuf_test_messages/proto3/test_messages_proto3.pb.go
+++ b/gen/protobuf_test_messages/proto3/test_messages_proto3.pb.go
@@ -11345,11 +11345,11 @@ func (this *EnumOnlyProto3) Equal(that interface{}) bool {
 
 func init() {
 	protohelpers.RegisterEnum("protobuf_test_messages.proto3.ForeignEnum", ForeignEnum_name, ForeignEnum_value)
-	protohelpers.RegisterEnum("protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum", TestAllTypesProto3_NestedEnum_name, TestAllTypesProto3_NestedEnum_value)
-	protohelpers.RegisterEnum("protobuf_test_messages.proto3.EnumOnlyProto3.Bool", EnumOnlyProto3_Bool_name, EnumOnlyProto3_Bool_value)
-	protohelpers.RegisterType((*TestAllTypesProto3)(nil), "protobuf_test_messages.proto3.TestAllTypesProto3")
 	protohelpers.RegisterType((*TestAllTypesProto3_NestedMessage)(nil), "protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage")
+	protohelpers.RegisterEnum("protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum", TestAllTypesProto3_NestedEnum_name, TestAllTypesProto3_NestedEnum_value)
+	protohelpers.RegisterType((*TestAllTypesProto3)(nil), "protobuf_test_messages.proto3.TestAllTypesProto3")
 	protohelpers.RegisterType((*ForeignMessage)(nil), "protobuf_test_messages.proto3.ForeignMessage")
 	protohelpers.RegisterType((*NullHypothesisProto3)(nil), "protobuf_test_messages.proto3.NullHypothesisProto3")
+	protohelpers.RegisterEnum("protobuf_test_messages.proto3.EnumOnlyProto3.Bool", EnumOnlyProto3_Bool_name, EnumOnlyProto3_Bool_value)
 	protohelpers.RegisterType((*EnumOnlyProto3)(nil), "protobuf_test_messages.proto3.EnumOnlyProto3")
 }


### PR DESCRIPTION
## Summary
- Add `forEachMessage`/`walkMessages` helper that replaces 10 duplicate recursive message-traversal pairs across the generator
- Add `presenceCheck`/`presenceSet` helpers that centralize the `fieldsPresent[W]&(1<<B)` bitmap arithmetic used in 5 emit files
- Collapse `emit_registration.go` type-switch recursion into a single `forEachMessage` call with inline callback

Net result: **-134 lines** with no behavioral change. Generated code diffs are only `init()` registration reordering (post-order vs pre-order), which is a no-op.

## Test plan
- [x] `go build ./compiler/...` compiles
- [x] `make generate-ours` regenerates successfully
- [x] `go test ./test/ ./compiler/...` passes
- [x] `make fuzz` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)