### PR TITLE
docs: record rejected //go:fix inline approach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,3 +110,21 @@ The generator smoke test (`TestGenerateMatchesCheckedIn`) only checks files that
 ## Known issues
 
 - `go test ./...` panics in `bench/` with `proto: file "maps.proto" is already registered` due to conflicting proto registrations between `gen/bench/official`, `gen/bench/vtpb`, and `gen/bench/gogopb`. Use `go test ./test/... ./compiler/...` to run tests without the bench package, or `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn go test ./bench/` to run benchmarks.
+
+## Rejected approaches
+
+Approaches that were investigated and deliberately not adopted. Documented to save future contributors from re-discovering the same dead ends.
+
+### `//go:fix inline` for hot-path helpers
+
+**Idea:** Have the generator emit calls to small helpers (`EncodeVarint`, `ConsumeVarint`, `ConsumeFixed32`, etc.) marked `//go:fix inline`, then run `go fix -inline ./...` as a codegen post-process step. Generator stays simple (single helper call per emit site); committed `.pb.go` ends up with the helper bodies inlined; we keep today's manual-inline performance.
+
+**Why it doesn't work:** Go's `inline` analyzer (Go 1.26, both `go fix -inline` and the standalone `golang.org/x/tools/go/analysis/passes/inline/cmd/inline` tool) only applies a fix when the call can be **reduced to an expression**. Multi-statement bodies — loops, early-return error paths, slice mutations — would require *literalization* (wrapping the body in `func(){...}()`), which the analyzer "discards unconditionally, on grounds of style" (per `go tool fix help inline`). The diagnostic still fires (`Call of X should be inlined [inline_call]`), but no source rewrite happens.
+
+For wiresmith specifically:
+
+- `protohelpers.EncodeVarint` has a `for` loop and slice writes → not inlined despite the directive. Confirmed: `go fix -inline ./gen/...` left every call site untouched.
+- `protohelpers.SizeOfVarint` is single-expression and *is* inlinable, but the generator already emits its body inline (`(bits.Len64(x|1)+6)/7`) so there are no call sites to fix in `gen/otlp/`, `gen/test/`, or `gen/protobuf_test_messages/`.
+- The proposed unmarshal-side helpers (`ConsumeVarint`, `ConsumeBytesLen`, `ConsumeFixed32`, `ConsumeFixed64`, `ConsumeTag`) all have loops and/or `return 0, 0, err` early-return paths → not inlinable. Extracting them would convert today's inlined unmarshal hot path into uninlined function calls, regressing the 25-28% speedup from commit `594501d` ("perf: inline varint/fixed decoding").
+
+**When this could become viable:** if the Go inliner gains the ability to apply non-literalized rewrites for multi-statement bodies at statement-level call sites (i.e. expand the body inline as a labeled block instead of refusing). Tracking issue: <https://github.com/golang/go/issues/32816> (the original `//go:fix inline` proposal). Until then, wiresmith's "emit the loop directly" approach in `compiler/types/type.go:114-196` and `compiler/generator/emit_unmarshal.go` is the only way to keep these paths inlined.


### PR DESCRIPTION
## Summary

- Investigated using `//go:fix inline` directives on `protohelpers` plus generator-extracted helpers (`ConsumeVarint`, `ConsumeBytesLen`, `ConsumeFixed32/64`, `ConsumeTag`) so `go fix -inline` would reproduce today's manual inlining as a codegen post-process step.
- Verified empirically that the Go 1.26 `inline` analyzer refuses to apply the rewrite for multi-statement bodies — loops, early-return error paths, slice mutations — because that would require *literalization* (`func(){...}()`) which the analyzer "discards unconditionally, on grounds of style" (`go tool fix help inline`).
- Net result: the directive fires diagnostics but `go fix -inline ./gen/...` leaves every call site in `gen/otlp/`, `gen/test/`, etc. untouched. Phase 1 would be a no-op; Phase 2 would be a perf regression (uninlined function calls on the hot path that 594501d spent 25-28% to inline).
- Recorded the finding in AGENTS.md under a new "Rejected approaches" section so the dead end is preserved for future contributors.

## Test plan

- [x] `git diff AGENTS.md` — only adds the new section, no functional changes
- [x] No code modified, no regenerated files, no test/bench impact