### PR TITLE
Auto-discover fuzz targets in make fuzz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,15 @@ coverage: ## Run tests with coverage report
 	@echo ""
 	@echo "HTML report: go tool cover -html=coverage.out"
 
-fuzz: ## Fuzz all targets (30s each)
-	@for target in FuzzUnmarshal FuzzRoundTrip FuzzMarshalSize FuzzCrossLibrary FuzzStructuredTrace FuzzStructuredMetrics FuzzStructuredLogs; do \
+fuzz: ## Fuzz all targets (30s each) — auto-discovers Fuzz* functions in ./test/fuzz/
+	@targets=$$(go test ./test/fuzz/ -list '^Fuzz' | grep '^Fuzz'); \
+	if [ -z "$$targets" ]; then \
+		echo "No fuzz targets found in ./test/fuzz/"; exit 1; \
+	fi; \
+	for target in $$targets; do \
 		echo "==> Fuzzing $$target..."; \
 		GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn \
-			go test ./test/fuzz/ -fuzz $$target -fuzztime 30s -run='^$$' || exit 1; \
+			go test ./test/fuzz/ -fuzz "^$$target$$" -fuzztime 30s -run='^$$' || exit 1; \
 	done
 
 generate: generate-ours generate-vtproto generate-gogoproto ## Regenerate all code (ours + vtproto + gogoproto)


### PR DESCRIPTION
## Summary
- `make fuzz` (called by CI) used a hardcoded list of fuzz target names. When `FuzzDifferentialBytewise` was added in `test/fuzz/differential_fuzz_test.go`, it wasn't added to the list — so CI silently stopped exercising it.
- Replace the hardcoded list with `go test ./test/fuzz/ -list '^Fuzz'` so every `Fuzz*` function in the package is run.

## Test plan
- [x] `make -n fuzz` shows the new dynamic loop.
- [x] Local smoke run with `-fuzztime 1s` per target fuzzes all 8 targets, including the previously missed `FuzzDifferentialBytewise`.
- [ ] CI Fuzz job runs all 8 targets at 30s each (~4 min total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)