### PR TITLE
test: extend fuzz coverage and recursive depth-limit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test: ## Run correctness tests
 	go test ./test/... -v
 
 coverage: ## Run tests with coverage report
-	go test ./test/... ./compiler/... -coverprofile=coverage.out
+	go test ./test/... ./compiler/... -coverpkg=./compiler/...,./gen/protohelpers/... -coverprofile=coverage.out
 	go tool cover -func=coverage.out
 	@echo ""
 	@echo "HTML report: go tool cover -html=coverage.out"

--- a/test/basic/depth_limit_test.go
+++ b/test/basic/depth_limit_test.go
@@ -20,7 +20,7 @@ func buildNestedAnyValueBytes(depth int) []byte {
 	inner := protowire.AppendTag(nil, 1, protowire.BytesType)
 	inner = protowire.AppendString(inner, "hello")
 
-	for i := 0; i < depth; i++ {
+	for range depth {
 		// Wrap inner AnyValue bytes in an ArrayValue.
 		// ArrayValue field 1 (repeated AnyValue): tag(1, BytesType) + len + inner
 		arrayValue := protowire.AppendTag(nil, 1, protowire.BytesType)
@@ -47,7 +47,7 @@ func TestUnmarshalDepthLimit(t *testing.T) {
 
 		// Verify the innermost value is accessible.
 		cur := &av
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			variant, ok := cur.Value.(*commonv1.AnyValue_ArrayValue)
 			require.True(t, ok, "expected ArrayValue at depth %d", i)
 			require.Len(t, variant.ArrayValue.Values, 1)
@@ -101,9 +101,10 @@ func buildNestedTreeNodeBytes(depth int) []byte {
 }
 
 // buildNestedNodeABytes builds a NodeA payload that nests through the
-// NodeA→NodeB→NodeA mutual-recursion chain. Each "step" alternates field 2
-// in NodeA (peer, optional NodeB) and field 2 in NodeB (parent, optional
-// NodeA), so two steps = 2 recursion increments.
+// NodeA→NodeB→NodeA mutual-recursion chain. Each "step" wraps the current
+// payload first as NodeB.parent (field 2, optional NodeA) and then as
+// NodeA.peer (field 2, optional NodeB), adding 2 recursion increments per
+// step.
 func buildNestedNodeABytes(steps int) []byte {
 	// Innermost: NodeA with name = "leaf" (field 1, string)
 	inner := protowire.AppendTag(nil, 1, protowire.BytesType)

--- a/test/basic/depth_limit_test.go
+++ b/test/basic/depth_limit_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"
 
+	rec "wiresmith/gen/basic/recursive/v1"
 	commonv1 "wiresmith/gen/otlp/common/v1"
 )
 
@@ -64,6 +65,109 @@ func TestUnmarshalDepthLimit(t *testing.T) {
 		b := buildNestedAnyValueBytes(10001)
 		var av commonv1.AnyValue
 		err := av.Unmarshal(b)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeded max recursion depth")
+	})
+}
+
+// buildNestedLinkedListBytes builds a depth-N LinkedList wire payload by
+// repeatedly wrapping the previous payload in field 2 (next, optional
+// LinkedList). Each wrap adds one level of recursion when unmarshaling.
+func buildNestedLinkedListBytes(depth int) []byte {
+	// Innermost: a LinkedList with value = 42 (field 1, varint)
+	inner := protowire.AppendTag(nil, 1, protowire.VarintType)
+	inner = protowire.AppendVarint(inner, 42)
+
+	for range depth {
+		outer := protowire.AppendTag(nil, 2, protowire.BytesType)
+		outer = protowire.AppendBytes(outer, inner)
+		inner = outer
+	}
+	return inner
+}
+
+// buildNestedTreeNodeBytes builds a depth-N TreeNode wire payload by repeatedly
+// wrapping the previous payload as a single child (field 3, repeated TreeNode).
+func buildNestedTreeNodeBytes(depth int) []byte {
+	inner := protowire.AppendTag(nil, 1, protowire.BytesType)
+	inner = protowire.AppendString(inner, "leaf")
+
+	for range depth {
+		outer := protowire.AppendTag(nil, 3, protowire.BytesType)
+		outer = protowire.AppendBytes(outer, inner)
+		inner = outer
+	}
+	return inner
+}
+
+// buildNestedNodeABytes builds a NodeA payload that nests through the
+// NodeA→NodeB→NodeA mutual-recursion chain. Each "step" alternates field 2
+// in NodeA (peer, optional NodeB) and field 2 in NodeB (parent, optional
+// NodeA), so two steps = 2 recursion increments.
+func buildNestedNodeABytes(steps int) []byte {
+	// Innermost: NodeA with name = "leaf" (field 1, string)
+	inner := protowire.AppendTag(nil, 1, protowire.BytesType)
+	inner = protowire.AppendString(inner, "leaf")
+
+	// Wrap pairs: NodeB(parent=NodeA(peer=...))
+	for range steps {
+		// Wrap as NodeB.parent (field 2, optional NodeA)
+		nb := protowire.AppendTag(nil, 2, protowire.BytesType)
+		nb = protowire.AppendBytes(nb, inner)
+		// Wrap as NodeA.peer (field 2, optional NodeB)
+		na := protowire.AppendTag(nil, 2, protowire.BytesType)
+		na = protowire.AppendBytes(na, nb)
+		inner = na
+	}
+	return inner
+}
+
+func TestRecursiveUnmarshalDepthLimit(t *testing.T) {
+	t.Run("LinkedList shallow", func(t *testing.T) {
+		b := buildNestedLinkedListBytes(5)
+		var ll rec.LinkedList
+		require.NoError(t, ll.Unmarshal(b))
+		require.NotNil(t, ll.Next)
+	})
+
+	t.Run("LinkedList exceeds limit", func(t *testing.T) {
+		// One level per wrap; 10001 wraps exceed maxUnmarshalDepth=10000.
+		b := buildNestedLinkedListBytes(10001)
+		var ll rec.LinkedList
+		err := ll.Unmarshal(b)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeded max recursion depth")
+	})
+
+	t.Run("TreeNode shallow", func(t *testing.T) {
+		b := buildNestedTreeNodeBytes(5)
+		var tn rec.TreeNode
+		require.NoError(t, tn.Unmarshal(b))
+		require.Len(t, tn.Children, 1)
+	})
+
+	t.Run("TreeNode exceeds limit", func(t *testing.T) {
+		b := buildNestedTreeNodeBytes(10001)
+		var tn rec.TreeNode
+		err := tn.Unmarshal(b)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeded max recursion depth")
+	})
+
+	t.Run("NodeA shallow", func(t *testing.T) {
+		b := buildNestedNodeABytes(3)
+		var na rec.NodeA
+		require.NoError(t, na.Unmarshal(b))
+		require.NotNil(t, na.Peer)
+		require.NotNil(t, na.Peer.Parent)
+	})
+
+	t.Run("NodeA exceeds limit", func(t *testing.T) {
+		// Each step adds 2 recursion increments (NodeA→NodeB→NodeA), so 5001
+		// steps = 10002 increments, past the 10000 limit.
+		b := buildNestedNodeABytes(5001)
+		var na rec.NodeA
+		err := na.Unmarshal(b)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "exceeded max recursion depth")
 	})

--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -37,7 +37,7 @@ func FuzzUnmarshal(f *testing.F) {
 	f.Add([]byte{0x0d, 0x01, 0x02, 0x03, 0x04})                         // fixed32 field
 	f.Add([]byte{0x09, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}) // fixed64 field
 
-	ctors := testutil.AllMessageConstructors()
+	ctors := testutil.AllPanicSafeConstructors()
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		for name, newMsg := range ctors {
@@ -93,12 +93,14 @@ func FuzzRoundTrip(f *testing.F) {
 // FuzzMarshalSize verifies that Size() matches the actual Marshal() output
 // length. A mismatch indicates a bug in size computation for some field
 // combination — especially relevant for nested messages with length prefixes.
+// Map iteration order does not affect the marshal length, so map-bearing
+// types are safe to include here.
 func FuzzMarshalSize(f *testing.F) {
 	for _, seed := range marshaledSeeds() {
 		f.Add(seed)
 	}
 
-	ctors := testutil.AllMessageConstructors()
+	ctors := testutil.AllPanicSafeConstructors()
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		for name, newMsg := range ctors {

--- a/test/testutil/testutil.go
+++ b/test/testutil/testutil.go
@@ -41,7 +41,6 @@ func AllMessageConstructors() map[string]func() Message {
 func MapBearingMessageConstructors() map[string]func() Message {
 	return map[string]func() Message{
 		"basic.MapBench":            func() Message { return new(mapsv1.MapBench) },
-		"basic.Inner":               func() Message { return new(mapsv1.Inner) },
 		"basic.EnumContainer":       func() Message { return new(enumv1.EnumContainer) },
 		"basic.OneofPlusEverything": func() Message { return new(oneofv1.OneofPlusEverything) },
 		"kitchensink.AllMaps":       func() Message { return new(kitchensinkv1.AllMaps) },
@@ -79,6 +78,9 @@ func basicMapFreeMessageConstructors() map[string]func() Message {
 
 		// basic/enum: nested enum (EnumContainer omitted — has signed_map)
 		"basic.WithNestedEnum": func() Message { return new(enumv1.WithNestedEnum) },
+
+		// basic/maps: map value-type message (no maps of its own)
+		"basic.maps.Inner": func() Message { return new(mapsv1.Inner) },
 
 		// basic/oneof: payload, multi-oneof, oneof with message/enum variants
 		"basic.Payload":        func() Message { return new(oneofv1.Payload) },

--- a/test/testutil/testutil.go
+++ b/test/testutil/testutil.go
@@ -1,12 +1,20 @@
 package testutil
 
 import (
+	"maps"
+	enumv1 "wiresmith/gen/basic/enum/v1"
+	mapsv1 "wiresmith/gen/basic/maps/v1"
+	nestingv1 "wiresmith/gen/basic/nesting/v1"
+	numericv1 "wiresmith/gen/basic/numeric/v1"
+	oneofv1 "wiresmith/gen/basic/oneof/v1"
+	recursivev1 "wiresmith/gen/basic/recursive/v1"
 	commonv1 "wiresmith/gen/otlp/common/v1"
 	logsv1 "wiresmith/gen/otlp/logs/v1"
 	metricsv1 "wiresmith/gen/otlp/metrics/v1"
 	profilesv1 "wiresmith/gen/otlp/profiles/v1development"
 	resourcev1 "wiresmith/gen/otlp/resource/v1"
 	tracev1 "wiresmith/gen/otlp/trace/v1"
+	kitchensinkv1 "wiresmith/gen/test/kitchensink/v1"
 )
 
 // Message is implemented by all generated message types.
@@ -16,8 +24,87 @@ type Message interface {
 	Size() int
 }
 
-// AllMessageConstructors returns a constructor for every OTLP generated message type.
+// AllMessageConstructors returns a constructor for every generated message
+// type whose marshal output is byte-deterministic across runs (i.e. has no
+// transitively-reachable map field). Suitable for tests that compare bytes
+// after a round-trip. For map-bearing types, see MapBearingMessageConstructors.
 func AllMessageConstructors() map[string]func() Message {
+	out := otlpMessageConstructors()
+	maps.Copy(out, basicMapFreeMessageConstructors())
+	return out
+}
+
+// MapBearingMessageConstructors returns constructors for generated types that
+// (transitively) contain map fields. Map iteration order is randomized in Go,
+// so byte-equal round-trip assertions are unsafe for these types — use them
+// in panic-only or size-only checks.
+func MapBearingMessageConstructors() map[string]func() Message {
+	return map[string]func() Message{
+		"basic.MapBench":            func() Message { return new(mapsv1.MapBench) },
+		"basic.Inner":               func() Message { return new(mapsv1.Inner) },
+		"basic.EnumContainer":       func() Message { return new(enumv1.EnumContainer) },
+		"basic.OneofPlusEverything": func() Message { return new(oneofv1.OneofPlusEverything) },
+		"kitchensink.AllMaps":       func() Message { return new(kitchensinkv1.AllMaps) },
+	}
+}
+
+// AllPanicSafeConstructors returns the union of map-free and map-bearing
+// constructors. Use it for tests that only need to verify "Unmarshal does not
+// panic" or "Size() == len(Marshal())".
+func AllPanicSafeConstructors() map[string]func() Message {
+	out := AllMessageConstructors()
+	maps.Copy(out, MapBearingMessageConstructors())
+	return out
+}
+
+// basicMapFreeMessageConstructors returns generated non-OTLP types that do not
+// contain any map fields (transitively), so their marshal output is
+// byte-deterministic.
+func basicMapFreeMessageConstructors() map[string]func() Message {
+	return map[string]func() Message{
+		// basic/recursive: self-referential pointer + slice
+		"basic.LinkedList": func() Message { return new(recursivev1.LinkedList) },
+		"basic.TreeNode":   func() Message { return new(recursivev1.TreeNode) },
+		"basic.NodeA":      func() Message { return new(recursivev1.NodeA) },
+		"basic.NodeB":      func() Message { return new(recursivev1.NodeB) },
+
+		// basic/numeric: unpacked repeated, mixed modifiers, wide bitmap
+		"basic.UnpackedScalars": func() Message { return new(numericv1.UnpackedScalars) },
+		"basic.MixedModifiers":  func() Message { return new(numericv1.MixedModifiers) },
+		"basic.WideFields":      func() Message { return new(numericv1.WideFields) },
+
+		// basic/nesting: 4-level inline messages
+		"basic.Level0":   func() Message { return new(nestingv1.Level0) },
+		"basic.CrossRef": func() Message { return new(nestingv1.CrossRef) },
+
+		// basic/enum: nested enum (EnumContainer omitted — has signed_map)
+		"basic.WithNestedEnum": func() Message { return new(enumv1.WithNestedEnum) },
+
+		// basic/oneof: payload, multi-oneof, oneof with message/enum variants
+		"basic.Payload":        func() Message { return new(oneofv1.Payload) },
+		"basic.MultiOneof":     func() Message { return new(oneofv1.MultiOneof) },
+		"basic.OneofWithTypes": func() Message { return new(oneofv1.OneofWithTypes) },
+
+		// test/kitchensink: every scalar shape and oneof type
+		"kitchensink.AllScalars":         func() Message { return new(kitchensinkv1.AllScalars) },
+		"kitchensink.AllOptionalScalars": func() Message { return new(kitchensinkv1.AllOptionalScalars) },
+		"kitchensink.AllRepeatedScalars": func() Message { return new(kitchensinkv1.AllRepeatedScalars) },
+		"kitchensink.OneofVariants":      func() Message { return new(kitchensinkv1.OneofVariants) },
+		"kitchensink.Outer":              func() Message { return new(kitchensinkv1.Outer) },
+		"kitchensink.Middle":             func() Message { return new(kitchensinkv1.Middle) },
+		"kitchensink.Inner":              func() Message { return new(kitchensinkv1.Inner) },
+		"kitchensink.HighFieldNumbers":   func() Message { return new(kitchensinkv1.HighFieldNumbers) },
+		"kitchensink.WithEnum":           func() Message { return new(kitchensinkv1.WithEnum) },
+		"kitchensink.Empty":              func() Message { return new(kitchensinkv1.Empty) },
+		"kitchensink.OnlyRepeated":       func() Message { return new(kitchensinkv1.OnlyRepeated) },
+		"kitchensink.Container":          func() Message { return new(kitchensinkv1.Container) },
+	}
+}
+
+// otlpMessageConstructors returns the OTLP generated message types. Kept
+// separate so AllMessageConstructors can compose with basic types and a future
+// caller can request OTLP-only if needed.
+func otlpMessageConstructors() map[string]func() Message {
 	return map[string]func() Message{
 		// common/v1
 		"AnyValue":             func() Message { return new(commonv1.AnyValue) },


### PR DESCRIPTION
## Summary

Three gaps surfaced when reviewing the testing strategy:

- **Fuzzers only saw OTLP types.** `proto/basic/`, `proto/test/kitchen_sink.proto`, and the conformance protos cover self-recursion, multi-oneof, wide presence-bitmaps, `packed=false`, and high field numbers — none of which were reachable from `FuzzUnmarshal`/`FuzzRoundTrip`/`FuzzMarshalSize`. `testutil` now exposes `AllMessageConstructors` (map-free OTLP + basic + kitchen_sink), `MapBearingMessageConstructors`, and `AllPanicSafeConstructors`. `FuzzUnmarshal` and `FuzzMarshalSize` use the panic-safe set; `FuzzRoundTrip` and `TestRandomPopulatedRoundTrip` get the map-free additions for free via the extended `AllMessageConstructors`. Fuzz baseline corpus jumps from 9→403 (`FuzzMarshalSize`) and 25→427 (`FuzzRoundTrip`).
- **Depth-limit only covered the `AnyValue→ArrayValue` cycle.** The optional-pointer recursion (`LinkedList`, `NodeA→NodeB`) and the repeated-slice recursion (`TreeNode`) used different generated paths but had no tests. Added `TestRecursiveUnmarshalDepthLimit` covering shallow + over-limit for all three shapes.
- **`make coverage` reported `compiler/types` as 0%** because `-coverpkg` wasn't set. Added `-coverpkg=./compiler/...,./gen/protohelpers/...`; total coverage now 95.9%, and the remaining 0%-functions are the (interface-mandated) panic stubs and unreachable classifier methods.

## Test plan

- [x] `go test ./test/... ./compiler/...` passes
- [x] `go vet ./test/... ./compiler/...` clean
- [x] `go test ./test/fuzz/ -fuzz '^FuzzRoundTrip$' -fuzztime 15s -run='^$'` passes against the expanded corpus
- [x] `go test ./test/fuzz/ -fuzz '^FuzzMarshalSize$' -fuzztime 15s -run='^$'` passes (includes map-bearing types)
- [x] `make coverage` produces a non-zero figure for `compiler/types/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)