### PR TITLE
feat: recursive proto directory scanning

### DIFF
--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -245,38 +245,66 @@ func oneofVariantName(md protoreflect.MessageDescriptor, fd protoreflect.FieldDe
 	return goMessageTypeName(md) + "_" + snakeToPascal(string(fd.Name()))
 }
 
-// buildImportMapping reads proto files and builds a mapping from import paths to file contents.
+// buildImportMapping reads proto files (recursively) and builds a mapping
+// from import paths to file contents. Top-level files are compiled under the
+// package-derived path so existing flat layouts keep working; nested files
+// use their relative path as the import key. The plain filename of every
+// top-level file is also registered so nested protos can import it.
 func buildImportMapping(protoDir string) (map[string][]byte, []string, error) {
-	entries, err := os.ReadDir(protoDir)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	mapping := make(map[string][]byte)
 	var importPaths []string
 	pkgRE := regexp.MustCompile(`(?m)^package\s+([\w.]+)\s*;`)
 
-	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".proto") {
-			continue
-		}
-		fullPath := filepath.Join(protoDir, entry.Name())
-		content, err := os.ReadFile(fullPath)
+	err := filepath.WalkDir(protoDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil, nil, err
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".proto") {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
 		}
 
 		m := pkgRE.FindSubmatch(content)
 		if m == nil {
-			return nil, nil, fmt.Errorf("no package found in %s", entry.Name())
+			return fmt.Errorf("no package found in %s", path)
+		}
+
+		rel, err := filepath.Rel(protoDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+
+		if strings.Contains(rel, "/") {
+			if _, exists := mapping[rel]; exists {
+				return fmt.Errorf("duplicate import key %q (from %s)", rel, path)
+			}
+			mapping[rel] = content
+			importPaths = append(importPaths, rel)
+			return nil
 		}
 
 		pkg := string(m[1])
-		importPath := strings.ReplaceAll(pkg, ".", "/") + "/" + entry.Name()
-		mapping[importPath] = content
-		importPaths = append(importPaths, importPath)
+		pkgKey := strings.ReplaceAll(pkg, ".", "/") + "/" + d.Name()
+		if _, exists := mapping[pkgKey]; exists {
+			return fmt.Errorf("duplicate import key %q (from %s)", pkgKey, path)
+		}
+		mapping[pkgKey] = content
+		importPaths = append(importPaths, pkgKey)
+		if rel != pkgKey {
+			mapping[rel] = content
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
 	}
 
+	sort.Strings(importPaths)
 	return mapping, importPaths, nil
 }
 

--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -102,9 +102,10 @@ func (g *Generator) Generate(ctx context.Context) error {
 	return nil
 }
 
-// outputPathFor returns the absolute output path for the .pb.go file that
-// will be produced for fd. The path is derived from the proto's package
-// (via goPackageDir) and basename, mirroring what generateFile writes.
+// outputPathFor returns the output path (relative to or under g.OutDir,
+// matching whatever shape OutDir has) for the .pb.go file that will be
+// produced for fd. The path is derived from the proto's package (via
+// goPackageDir) and basename, mirroring what generateFile writes.
 func (g *Generator) outputPathFor(fd protoreflect.FileDescriptor) string {
 	dir := filepath.Join(g.OutDir, goPackageDir(string(fd.Package())))
 	base := strings.TrimSuffix(filepath.Base(fd.Path()), ".proto") + ".pb.go"

--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -80,12 +80,35 @@ func (g *Generator) Generate(ctx context.Context) error {
 		return fmt.Errorf("compiling protos: %w", err)
 	}
 
+	// Detect output-path collisions up front, before writing any files. Two
+	// protos in different directories with the same package and same basename
+	// would otherwise silently clobber each other on disk — recursive scanning
+	// makes this collision possible where flat layouts could not produce it.
+	outputs := make(map[string]string, len(results))
+	for _, fd := range results {
+		outPath := g.outputPathFor(fd)
+		if prev, exists := outputs[outPath]; exists {
+			return fmt.Errorf("output collision at %s: %q and %q produce the same file (same package %q + basename)",
+				outPath, prev, fd.Path(), fd.Package())
+		}
+		outputs[outPath] = fd.Path()
+	}
+
 	for _, fd := range results {
 		if err := g.generateFile(fd); err != nil {
 			return fmt.Errorf("generating %s: %w", fd.Path(), err)
 		}
 	}
 	return nil
+}
+
+// outputPathFor returns the absolute output path for the .pb.go file that
+// will be produced for fd. The path is derived from the proto's package
+// (via goPackageDir) and basename, mirroring what generateFile writes.
+func (g *Generator) outputPathFor(fd protoreflect.FileDescriptor) string {
+	dir := filepath.Join(g.OutDir, goPackageDir(string(fd.Package())))
+	base := strings.TrimSuffix(filepath.Base(fd.Path()), ".proto") + ".pb.go"
+	return filepath.Join(dir, base)
 }
 
 func (g *Generator) generateFile(fd protoreflect.FileDescriptor) error {
@@ -119,16 +142,10 @@ func (g *Generator) generateFile(fd protoreflect.FileDescriptor) error {
 		fmt.Fprintf(os.Stderr, "warning: format error for %s: %v\n", fd.Path(), err)
 	}
 
-	pkg := string(fd.Package())
-	dir := filepath.Join(g.OutDir, goPackageDir(pkg))
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	outPath := g.outputPathFor(fd)
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return err
 	}
-
-	// Use the proto filename without extension as the Go filename
-	base := filepath.Base(fd.Path())
-	base = strings.TrimSuffix(base, ".proto") + ".pb.go"
-	outPath := filepath.Join(dir, base)
 
 	return os.WriteFile(outPath, formatted, 0o644)
 }
@@ -246,10 +263,15 @@ func oneofVariantName(md protoreflect.MessageDescriptor, fd protoreflect.FieldDe
 }
 
 // buildImportMapping reads proto files (recursively) and builds a mapping
-// from import paths to file contents. Top-level files are compiled under the
-// package-derived path so existing flat layouts keep working; nested files
-// use their relative path as the import key. The plain filename of every
-// top-level file is also registered so nested protos can import it.
+// from import paths to file contents. Top-level files are registered under
+// the package-derived path so existing flat layouts keep working; nested
+// files use their on-disk relative path as the import key.
+//
+// Each file is registered under exactly one canonical path. Imports across
+// files must use that canonical form: package-derived for top-level files,
+// relative-path for nested files. Registering the same content under two
+// keys would cause protocompile to compile it twice and emit duplicate-symbol
+// errors when a consumer imports it via the non-canonical name.
 func buildImportMapping(protoDir string) (map[string][]byte, []string, error) {
 	mapping := make(map[string][]byte)
 	var importPaths []string
@@ -279,25 +301,18 @@ func buildImportMapping(protoDir string) (map[string][]byte, []string, error) {
 		}
 		rel = filepath.ToSlash(rel)
 
+		var key string
 		if strings.Contains(rel, "/") {
-			if _, exists := mapping[rel]; exists {
-				return fmt.Errorf("duplicate import key %q (from %s)", rel, path)
-			}
-			mapping[rel] = content
-			importPaths = append(importPaths, rel)
-			return nil
+			key = rel
+		} else {
+			pkg := string(m[1])
+			key = strings.ReplaceAll(pkg, ".", "/") + "/" + d.Name()
 		}
-
-		pkg := string(m[1])
-		pkgKey := strings.ReplaceAll(pkg, ".", "/") + "/" + d.Name()
-		if _, exists := mapping[pkgKey]; exists {
-			return fmt.Errorf("duplicate import key %q (from %s)", pkgKey, path)
+		if _, exists := mapping[key]; exists {
+			return fmt.Errorf("duplicate import key %q (from %s)", key, path)
 		}
-		mapping[pkgKey] = content
-		importPaths = append(importPaths, pkgKey)
-		if rel != pkgKey {
-			mapping[rel] = content
-		}
+		mapping[key] = content
+		importPaths = append(importPaths, key)
 		return nil
 	})
 	if err != nil {

--- a/compiler/generator/generator_test.go
+++ b/compiler/generator/generator_test.go
@@ -286,7 +286,12 @@ func TestBuildImportMappingFlat(t *testing.T) {
 	}
 	// Top-level file uses package-derived key as its canonical path.
 	if _, ok := mapping["test/foo/foo.proto"]; !ok {
-		t.Errorf("expected key test/foo/foo.proto, got keys: %v", importPaths)
+		keys := make([]string, 0, len(mapping))
+		for k := range mapping {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		t.Errorf("expected key test/foo/foo.proto in mapping, got keys: %v", keys)
 	}
 	// The plain filename must not be registered — doing so would cause
 	// protocompile to compile the same content twice if a consumer imported

--- a/compiler/generator/generator_test.go
+++ b/compiler/generator/generator_test.go
@@ -284,13 +284,15 @@ func TestBuildImportMappingFlat(t *testing.T) {
 	if len(importPaths) != 1 {
 		t.Fatalf("expected 1 import path, got %d", len(importPaths))
 	}
-	// Top-level file uses package-derived key for compilation.
+	// Top-level file uses package-derived key as its canonical path.
 	if _, ok := mapping["test/foo/foo.proto"]; !ok {
 		t.Errorf("expected key test/foo/foo.proto, got keys: %v", importPaths)
 	}
-	// Plain filename also registered in resolver so nested protos can import it.
-	if _, ok := mapping["foo.proto"]; !ok {
-		t.Error("expected plain key foo.proto in mapping for resolver")
+	// The plain filename must not be registered — doing so would cause
+	// protocompile to compile the same content twice if a consumer imported
+	// it via the basename, producing a duplicate-symbol error.
+	if _, ok := mapping["foo.proto"]; ok {
+		t.Error("plain filename foo.proto should not be aliased; only canonical pkg-derived key should exist")
 	}
 }
 
@@ -378,5 +380,121 @@ func TestBuildImportMappingDuplicateKey(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "duplicate import key") {
 		t.Errorf("expected 'duplicate import key' error, got: %v", err)
+	}
+}
+
+// TestGenerateNestedLayout runs the full generator pipeline against a
+// recursive proto layout where a nested file imports another nested file.
+// This is the integration-level counterpart to TestBuildImportMappingRecursive:
+// it verifies the import keys we register actually resolve through protocompile
+// and that .pb.go files land at the expected goPackageDir locations.
+func TestGenerateNestedLayout(t *testing.T) {
+	protoDir := t.TempDir()
+	writeProto(t, protoDir, "common/v1/common.proto",
+		"syntax = \"proto3\";\npackage testpb.common.v1;\nmessage Resource { string name = 1; }")
+	writeProto(t, protoDir, "trace/v1/trace.proto",
+		"syntax = \"proto3\";\npackage testpb.trace.v1;\nimport \"common/v1/common.proto\";\nmessage Span { testpb.common.v1.Resource resource = 1; }")
+
+	outDir := t.TempDir()
+	gen := &Generator{Module: "wiresmith", OutDir: outDir, ProtoDir: protoDir}
+	if err := gen.Generate(context.Background()); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	for _, rel := range []string{
+		filepath.Join("testpb", "common", "v1", "common.pb.go"),
+		filepath.Join("testpb", "trace", "v1", "trace.pb.go"),
+	} {
+		path := filepath.Join(outDir, rel)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("expected generated file %s: %v", rel, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("generated file %s is empty", rel)
+		}
+	}
+
+	// The cross-file import must be reflected in the consumer file: trace.pb.go
+	// should reference the common package's Go import path so it actually
+	// compiles. A missing import would mean protocompile resolved the .proto
+	// import but the generator dropped it.
+	traceContent, err := os.ReadFile(filepath.Join(outDir, "testpb", "trace", "v1", "trace.pb.go"))
+	if err != nil {
+		t.Fatalf("reading trace.pb.go: %v", err)
+	}
+	if !strings.Contains(string(traceContent), "wiresmith/gen/testpb/common/v1") {
+		t.Errorf("trace.pb.go missing cross-package import to common/v1; content:\n%s", traceContent)
+	}
+}
+
+// TestGenerateMixedLayoutImport documents the supported import shape for a
+// mixed flat+nested layout: a nested file importing a top-level file must
+// use the top-level's package-derived path (its canonical key), not the
+// plain basename. The plain-basename form fails because protocompile uses
+// the queried path as file identity and would compile the file twice.
+func TestGenerateMixedLayoutImport(t *testing.T) {
+	protoDir := t.TempDir()
+	writeProto(t, protoDir, "common.proto",
+		"syntax = \"proto3\";\npackage testpb;\nmessage Resource { string name = 1; }")
+	writeProto(t, protoDir, "trace/v1/trace.proto",
+		"syntax = \"proto3\";\npackage testpb.trace.v1;\nimport \"testpb/common.proto\";\nmessage Span { testpb.Resource resource = 1; }")
+
+	outDir := t.TempDir()
+	gen := &Generator{Module: "wiresmith", OutDir: outDir, ProtoDir: protoDir}
+	if err := gen.Generate(context.Background()); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	for _, rel := range []string{
+		filepath.Join("testpb", "common.pb.go"),
+		filepath.Join("testpb", "trace", "v1", "trace.pb.go"),
+	} {
+		if _, err := os.Stat(filepath.Join(outDir, rel)); err != nil {
+			t.Errorf("expected generated file %s: %v", rel, err)
+		}
+	}
+
+	// The plain-basename form must be rejected: registering both keys for the
+	// same content would cause protocompile to compile it twice and emit a
+	// duplicate-symbol error.
+	protoDir2 := t.TempDir()
+	writeProto(t, protoDir2, "common.proto",
+		"syntax = \"proto3\";\npackage testpb;\nmessage Resource { string name = 1; }")
+	writeProto(t, protoDir2, "trace/v1/trace.proto",
+		"syntax = \"proto3\";\npackage testpb.trace.v1;\nimport \"common.proto\";\nmessage Span { testpb.Resource resource = 1; }")
+	gen2 := &Generator{Module: "wiresmith", OutDir: t.TempDir(), ProtoDir: protoDir2}
+	if err := gen2.Generate(context.Background()); err == nil {
+		t.Error("expected plain-basename import to fail; canonical pkg-derived path is required for cross-imports")
+	}
+}
+
+// TestGenerateOutputCollision verifies that two protos in different
+// subdirectories sharing the same package and basename are rejected
+// before any file is written. Without this guard, recursive scanning
+// would silently clobber the first .pb.go with the second.
+func TestGenerateOutputCollision(t *testing.T) {
+	protoDir := t.TempDir()
+	writeProto(t, protoDir, "a/v1/shared.proto",
+		"syntax = \"proto3\";\npackage testpb.shared.v1;\nmessage A {}")
+	writeProto(t, protoDir, "b/v1/shared.proto",
+		"syntax = \"proto3\";\npackage testpb.shared.v1;\nmessage B {}")
+
+	outDir := t.TempDir()
+	gen := &Generator{Module: "wiresmith", OutDir: outDir, ProtoDir: protoDir}
+	err := gen.Generate(context.Background())
+	if err == nil {
+		t.Fatal("expected output-collision error, got nil")
+	}
+	if !strings.Contains(err.Error(), "output collision") {
+		t.Errorf("expected 'output collision' error, got: %v", err)
+	}
+
+	// Fail-fast guarantee: no .pb.go should have been written before the
+	// collision was detected.
+	collisionDir := filepath.Join(outDir, "testpb", "shared", "v1")
+	if entries, err := os.ReadDir(collisionDir); err == nil && len(entries) > 0 {
+		t.Errorf("expected no files written on collision, found %d in %s", len(entries), collisionDir)
 	}
 }

--- a/compiler/generator/generator_test.go
+++ b/compiler/generator/generator_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -258,5 +259,124 @@ func TestGenerateMatchesCheckedIn(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func writeProto(t *testing.T, dir, relPath, content string) {
+	t.Helper()
+	full := filepath.Join(dir, relPath)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildImportMappingFlat(t *testing.T) {
+	dir := t.TempDir()
+	writeProto(t, dir, "foo.proto", "syntax = \"proto3\";\npackage test.foo;\nmessage Foo {}")
+
+	mapping, importPaths, err := buildImportMapping(dir)
+	if err != nil {
+		t.Fatalf("buildImportMapping: %v", err)
+	}
+	if len(importPaths) != 1 {
+		t.Fatalf("expected 1 import path, got %d", len(importPaths))
+	}
+	// Top-level file uses package-derived key for compilation.
+	if _, ok := mapping["test/foo/foo.proto"]; !ok {
+		t.Errorf("expected key test/foo/foo.proto, got keys: %v", importPaths)
+	}
+	// Plain filename also registered in resolver so nested protos can import it.
+	if _, ok := mapping["foo.proto"]; !ok {
+		t.Error("expected plain key foo.proto in mapping for resolver")
+	}
+}
+
+func TestBuildImportMappingRecursive(t *testing.T) {
+	dir := t.TempDir()
+	writeProto(t, dir, "common/v1/common.proto",
+		"syntax = \"proto3\";\npackage tempopb.common.v1;\nmessage Foo {}")
+	writeProto(t, dir, "trace/v1/trace.proto",
+		"syntax = \"proto3\";\npackage tempopb.trace.v1;\nimport \"common/v1/common.proto\";\nmessage Bar { tempopb.common.v1.Foo foo = 1; }")
+
+	mapping, importPaths, err := buildImportMapping(dir)
+	if err != nil {
+		t.Fatalf("buildImportMapping: %v", err)
+	}
+	if len(importPaths) != 2 {
+		t.Fatalf("expected 2 import paths, got %d: %v", len(importPaths), importPaths)
+	}
+	if _, ok := mapping["common/v1/common.proto"]; !ok {
+		t.Error("expected common/v1/common.proto in mapping")
+	}
+	if _, ok := mapping["trace/v1/trace.proto"]; !ok {
+		t.Error("expected trace/v1/trace.proto in mapping")
+	}
+	// Determinism: importPaths must be sorted.
+	sorted := make([]string, len(importPaths))
+	copy(sorted, importPaths)
+	sort.Strings(sorted)
+	for i := range importPaths {
+		if importPaths[i] != sorted[i] {
+			t.Errorf("import paths not sorted: %v", importPaths)
+			break
+		}
+	}
+}
+
+func TestBuildImportMappingMixed(t *testing.T) {
+	dir := t.TempDir()
+	writeProto(t, dir, "root.proto",
+		"syntax = \"proto3\";\npackage mypkg;\nmessage Root {}")
+	writeProto(t, dir, "sub/v1/nested.proto",
+		"syntax = \"proto3\";\npackage mypkg.sub.v1;\nmessage Nested {}")
+
+	mapping, importPaths, err := buildImportMapping(dir)
+	if err != nil {
+		t.Fatalf("buildImportMapping: %v", err)
+	}
+	if len(importPaths) != 2 {
+		t.Fatalf("expected 2 import paths, got %d: %v", len(importPaths), importPaths)
+	}
+	if _, ok := mapping["mypkg/root.proto"]; !ok {
+		t.Error("expected mypkg/root.proto for top-level file")
+	}
+	if _, ok := mapping["sub/v1/nested.proto"]; !ok {
+		t.Error("expected sub/v1/nested.proto for nested file")
+	}
+}
+
+func TestBuildImportMappingNoPackage(t *testing.T) {
+	dir := t.TempDir()
+	writeProto(t, dir, "bare.proto", "syntax = \"proto3\";\nmessage Bare {}")
+
+	_, _, err := buildImportMapping(dir)
+	if err == nil {
+		t.Fatal("expected error for proto without package, got nil")
+	}
+	if !strings.Contains(err.Error(), "no package found") {
+		t.Errorf("expected 'no package found' error, got: %v", err)
+	}
+}
+
+// TestBuildImportMappingDuplicateKey covers the realistic collision: a
+// top-level file's package-derived key collides with a nested file's
+// relative-path key (e.g. top-level foo.proto with `package bar` produces
+// key `bar/foo.proto`, same as a nested file at `bar/foo.proto`).
+func TestBuildImportMappingDuplicateKey(t *testing.T) {
+	dir := t.TempDir()
+	writeProto(t, dir, "foo.proto",
+		"syntax = \"proto3\";\npackage bar;\nmessage Foo {}")
+	writeProto(t, dir, "bar/foo.proto",
+		"syntax = \"proto3\";\npackage bar;\nmessage Foo {}")
+
+	_, _, err := buildImportMapping(dir)
+	if err == nil {
+		t.Fatal("expected duplicate-key error, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate import key") {
+		t.Errorf("expected 'duplicate import key' error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace `os.ReadDir` with `filepath.WalkDir` in `buildImportMapping` so nested proto layouts (e.g. `tempopb/{common,trace}/v1/*.proto`) can be generated in one pass.
- Flat layouts keep their package-derived import keys — generated output is byte-identical to before.
- Each file is registered under exactly one canonical path: package-derived for top-level files, relative-path for nested files. Cross-imports must use the canonical form (e.g. nested protos import a top-level file via `import "pkg/foo.proto"`, not `import "foo.proto"`). Registering basename aliases would cause protocompile to compile the same file twice and emit duplicate-symbol errors.
- Duplicate import keys now return an explicit error instead of silently overwriting.
- Import paths are sorted before compilation for deterministic output.
- Output-path collisions (two protos in different subdirs sharing the same package + basename) are detected up front in `Generate`, before any file is written.

Extracted from #40 as a self-contained change — no CLI surface, naming, or generated-code differences. The other features in #40 (`--strip_prefix`, `--import_base`, `--helpers_import`, `go_package` support, alias disambiguation) will follow as separate PRs.

## Test plan

- [x] `go test ./compiler/... ./test/...` — passes
- [x] `make generate-ours` produces no diff under `gen/`
- [x] Eight new tests in `generator_test.go`: `TestBuildImportMapping{Flat,Recursive,Mixed,NoPackage,DuplicateKey}`, `TestGenerateNestedLayout`, `TestGenerateMixedLayoutImport`, `TestGenerateOutputCollision`
- [x] Coverage of `buildImportMapping` rose from 81.1% to 89.2% (remaining gaps are I/O error paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)