### PR TITLE
fix: detect value-type message cycles before codegen (wiresmith-6ii)

### DIFF
--- a/compiler/generator/cycle_check.go
+++ b/compiler/generator/cycle_check.go
@@ -1,0 +1,334 @@
+package generator
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/bufbuild/protocompile/linker"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// valueEdge is a single value-type-field reference from one message to
+// another, used by the cycle check to build its directed graph.
+type valueEdge struct {
+	field protoreflect.FieldDescriptor
+	to    protoreflect.FullName
+}
+
+// validateNoValueCycles rejects any cycle of value-type message fields. A
+// cycle in this subgraph would make wiresmith emit a recursively-sized Go
+// struct (e.g. `type Tree struct { Child Tree }`), which `go build` rejects
+// as "invalid recursive type". The cycle becomes legal once any edge along
+// the cycle is broken with `optional`, `repeated`, a `map<>`, a `oneof`, or
+// `[(wiresmith.options.pointer) = true]`.
+//
+// Run after resolvePointerExtension and validatePointerOptions and before
+// any emit pass, so cycle errors surface up front rather than as a confusing
+// gofmt / go build failure on the generated output.
+//
+// Across-file recursion is detected too: the function walks every
+// non-internal file in results, so a cycle involving messages from two
+// proto packages is reported the same way as a same-file self-reference.
+func (g *Generator) validateNoValueCycles(results linker.Files) error {
+	mds := collectExternalMessages(results)
+	if len(mds) == 0 {
+		return nil
+	}
+
+	// Adjacency: message FullName -> outgoing value-type edges. We index
+	// messages by FullName so cycles across files resolve through a single
+	// node identity even when the same descriptor is encountered via different
+	// file walks.
+	nodes := make(map[protoreflect.FullName]protoreflect.MessageDescriptor, len(mds))
+	adj := make(map[protoreflect.FullName][]valueEdge, len(mds))
+	for _, md := range mds {
+		name := md.FullName()
+		nodes[name] = md
+		for i := 0; i < md.Fields().Len(); i++ {
+			fd := md.Fields().Get(i)
+			if !g.isValueRecursionEdge(fd) {
+				continue
+			}
+			adj[name] = append(adj[name], valueEdge{field: fd, to: fd.Message().FullName()})
+		}
+	}
+
+	sccs := tarjanSCC(nodes, adj)
+
+	// Report cycles: an SCC of size > 1 is always a cycle; an SCC of size 1
+	// is a cycle iff the single node has a self-loop edge.
+	var cycleMsgs []string
+	for _, scc := range sccs {
+		isCycle := len(scc) > 1
+		if !isCycle {
+			only := scc[0]
+			for _, e := range adj[only] {
+				if e.to == only {
+					isCycle = true
+					break
+				}
+			}
+		}
+		if !isCycle {
+			continue
+		}
+		cycleMsgs = append(cycleMsgs, describeCycle(scc, adj))
+	}
+	if len(cycleMsgs) == 0 {
+		return nil
+	}
+	slices.Sort(cycleMsgs)
+
+	var out strings.Builder
+	out.WriteString("value-type message field cycle detected — generated Go would be a recursively-sized struct that does not compile.\nBreak the cycle by marking one of the fields below with `optional` (becomes a pointer with proto3-optional semantics), `[(wiresmith.options.pointer) = true]` (becomes a pointer without optional semantics), or by changing it to `repeated`, `map<>`, or a oneof variant:\n")
+	for _, m := range cycleMsgs {
+		out.WriteString("  - ")
+		out.WriteString(m)
+		out.WriteByte('\n')
+	}
+	return fmt.Errorf("%s", out.String())
+}
+
+// isValueRecursionEdge reports whether fd produces a value-type Go struct
+// field that would participate in a recursive-size compile error.
+//
+// The set of disqualifiers mirrors the goFieldType / fieldType dispatch: any
+// shape that surfaces as a pointer, slice, map, or interface in Go is safe
+// to recurse through. Specifically:
+//
+//   - non-message kinds can't introduce message recursion
+//   - map fields surface as `map[K]V` (heap-allocated entries)
+//   - oneof variants surface through an interface
+//   - `optional` fields surface as `*T`
+//   - repeated fields surface as `[]T`
+//   - `(wiresmith.options.pointer) = true` fields surface as `*T` / `[]*T`
+//
+// Everything else is a singular value-type message field — exactly the shape
+// that emits `Child Type` and breaks `go build` on recursion.
+func (g *Generator) isValueRecursionEdge(fd protoreflect.FieldDescriptor) bool {
+	if fd.Kind() != protoreflect.MessageKind {
+		return false
+	}
+	if fd.IsMap() {
+		return false
+	}
+	if isRealOneof(fd) {
+		return false
+	}
+	if fd.HasOptionalKeyword() {
+		return false
+	}
+	if fd.IsList() {
+		return false
+	}
+	if hasPointerOption(g.pointerExt, fd) {
+		return false
+	}
+	return true
+}
+
+// collectExternalMessages returns every non-map-entry message from every
+// non-internal file in results. Internal schema files (the embedded
+// wiresmith/options.proto) are skipped so the cycle check only considers
+// user-facing types.
+func collectExternalMessages(results linker.Files) []protoreflect.MessageDescriptor {
+	var out []protoreflect.MessageDescriptor
+	seen := make(map[protoreflect.FullName]bool)
+	for _, fd := range results {
+		if isInternalSchemaFile(fd) {
+			continue
+		}
+		forEachMessage(fd, func(md protoreflect.MessageDescriptor) {
+			name := md.FullName()
+			if seen[name] {
+				return
+			}
+			seen[name] = true
+			out = append(out, md)
+		})
+	}
+	return out
+}
+
+// tarjanSCC returns the strongly connected components of the message graph
+// described by nodes and adj. Implementation is iterative to avoid blowing
+// the Go stack on pathological import depths. Edges whose target is not in
+// nodes are simply skipped — they can't participate in a cycle that re-enters
+// the user-facing graph.
+//
+// Output ordering is stable: outer iteration starts from sorted node names
+// so the resulting SCC ordering is reproducible across runs.
+func tarjanSCC(
+	nodes map[protoreflect.FullName]protoreflect.MessageDescriptor,
+	adj map[protoreflect.FullName][]valueEdge,
+) [][]protoreflect.FullName {
+	type info struct {
+		index, lowlink int
+		onStack        bool
+		visited        bool
+	}
+	state := make(map[protoreflect.FullName]*info, len(nodes))
+	var stack []protoreflect.FullName
+	idx := 0
+	var sccs [][]protoreflect.FullName
+
+	type frame struct {
+		node    protoreflect.FullName
+		edgeIdx int
+	}
+
+	visit := func(start protoreflect.FullName) {
+		if s := state[start]; s != nil && s.visited {
+			return
+		}
+		state[start] = &info{index: idx, lowlink: idx, onStack: true, visited: true}
+		idx++
+		stack = append(stack, start)
+		frames := []frame{{node: start, edgeIdx: 0}}
+
+		for len(frames) > 0 {
+			top := &frames[len(frames)-1]
+			vInfo := state[top.node]
+			edges := adj[top.node]
+
+			if top.edgeIdx < len(edges) {
+				w := edges[top.edgeIdx].to
+				top.edgeIdx++
+				if _, known := nodes[w]; !known {
+					continue
+				}
+				wInfo := state[w]
+				if wInfo == nil {
+					state[w] = &info{index: idx, lowlink: idx, onStack: true, visited: true}
+					idx++
+					stack = append(stack, w)
+					frames = append(frames, frame{node: w, edgeIdx: 0})
+					continue
+				}
+				if wInfo.onStack && wInfo.index < vInfo.lowlink {
+					vInfo.lowlink = wInfo.index
+				}
+				continue
+			}
+
+			if vInfo.lowlink == vInfo.index {
+				var scc []protoreflect.FullName
+				for {
+					w := stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+					state[w].onStack = false
+					scc = append(scc, w)
+					if w == top.node {
+						break
+					}
+				}
+				sccs = append(sccs, scc)
+			}
+
+			poppedNode := top.node
+			frames = frames[:len(frames)-1]
+			if len(frames) > 0 {
+				parent := state[frames[len(frames)-1].node]
+				if state[poppedNode].lowlink < parent.lowlink {
+					parent.lowlink = state[poppedNode].lowlink
+				}
+			}
+		}
+	}
+
+	starts := make([]protoreflect.FullName, 0, len(nodes))
+	for name := range nodes {
+		starts = append(starts, name)
+	}
+	slices.Sort(starts)
+	for _, name := range starts {
+		visit(name)
+	}
+	return sccs
+}
+
+// describeCycle renders a single SCC as a human-readable cycle path.
+// For a self-loop, the output is `pkg.Msg.field (type pkg.Msg)`. For a
+// longer cycle, we walk one DFS path through the SCC starting from its
+// alphabetically-first node and chain its edges back to that start.
+//
+// We can't always find a single Hamiltonian path through an arbitrary SCC,
+// but a cycle is guaranteed to exist — so we just pick any cycle by greedy
+// DFS over edges that stay inside the SCC.
+func describeCycle(scc []protoreflect.FullName, adj map[protoreflect.FullName][]valueEdge) string {
+	if len(scc) == 1 {
+		only := scc[0]
+		for _, e := range adj[only] {
+			if e.to == only {
+				return fmt.Sprintf("%s.%s (type %s)", only, e.field.Name(), only)
+			}
+		}
+		return fmt.Sprintf("%s (self-cycle)", only)
+	}
+
+	inScc := make(map[protoreflect.FullName]bool, len(scc))
+	for _, n := range scc {
+		inScc[n] = true
+	}
+
+	names := make([]protoreflect.FullName, len(scc))
+	copy(names, scc)
+	slices.Sort(names)
+	start := names[0]
+
+	type step struct {
+		from  protoreflect.FullName
+		field protoreflect.FieldDescriptor
+		to    protoreflect.FullName
+	}
+	var path []step
+	visited := map[protoreflect.FullName]bool{}
+	var dfs func(node protoreflect.FullName) bool
+	dfs = func(node protoreflect.FullName) bool {
+		visited[node] = true
+		edges := make([]valueEdge, len(adj[node]))
+		copy(edges, adj[node])
+		sort.Slice(edges, func(i, j int) bool {
+			if edges[i].to == edges[j].to {
+				return edges[i].field.Name() < edges[j].field.Name()
+			}
+			return edges[i].to < edges[j].to
+		})
+		for _, e := range edges {
+			if !inScc[e.to] {
+				continue
+			}
+			if e.to == start && len(path) > 0 {
+				path = append(path, step{from: node, field: e.field, to: e.to})
+				return true
+			}
+			if visited[e.to] {
+				continue
+			}
+			path = append(path, step{from: node, field: e.field, to: e.to})
+			if dfs(e.to) {
+				return true
+			}
+			path = path[:len(path)-1]
+		}
+		return false
+	}
+	dfs(start)
+
+	if len(path) == 0 {
+		parts := make([]string, len(scc))
+		for i, n := range scc {
+			parts[i] = string(n)
+		}
+		return strings.Join(parts, " <-> ")
+	}
+
+	parts := make([]string, 0, len(path)+1)
+	parts = append(parts, string(start))
+	for _, s := range path {
+		parts = append(parts, fmt.Sprintf("--(field %q)--> %s", s.field.Name(), s.to))
+	}
+	return strings.Join(parts, " ")
+}

--- a/compiler/generator/cycle_check_test.go
+++ b/compiler/generator/cycle_check_test.go
@@ -1,0 +1,279 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+)
+
+// expectCycleError fails the test if err is nil or does not look like the
+// cycle-detection error produced by validateNoValueCycles. The header is the
+// stable anchor; the per-cycle line is matched separately by reasonSubstr so
+// callers can pin the specific cycle they expect to be reported.
+func expectCycleError(t *testing.T, err error, reasonSubstr string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "value-type message field cycle detected") {
+		t.Errorf("missing header in error: %s", msg)
+	}
+	if !strings.Contains(msg, reasonSubstr) {
+		t.Errorf("missing reason %q in error: %s", reasonSubstr, msg)
+	}
+}
+
+// TestCycleCheck_SelfReferenceRejected is the headline case from CR-4: a
+// message with a value-typed self-reference would otherwise emit `Child Tree`
+// inside `type Tree struct`, which `go build` rejects as a recursively-sized
+// type. The cycle check must intercept this before any file is written.
+func TestCycleCheck_SelfReferenceRejected(t *testing.T) {
+	err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message Tree {
+  Tree child = 1;
+}
+`)
+	expectCycleError(t, err, "test.Tree.child")
+}
+
+// TestCycleCheck_MutualRecursionRejected covers the two-message cycle:
+// A holds a value-typed B and B holds a value-typed A. Each struct's size
+// would depend on the other's, so the cycle is just as fatal as a direct
+// self-reference. The reported cycle path must mention both fields so the
+// user can pick either to break.
+func TestCycleCheck_MutualRecursionRejected(t *testing.T) {
+	err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message A {
+  B b = 1;
+}
+message B {
+  A a = 1;
+}
+`)
+	expectCycleError(t, err, "test.A")
+	if err != nil && !strings.Contains(err.Error(), "test.B") {
+		t.Errorf("expected both A and B in cycle error, got: %s", err.Error())
+	}
+}
+
+// TestCycleCheck_LongerCycleRejected pins the three-node cycle A -> B -> C -> A.
+// Tarjan's SCC must collapse the entire cycle into a single component and the
+// description walks the cycle so the user sees the full chain.
+func TestCycleCheck_LongerCycleRejected(t *testing.T) {
+	err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message A { B b = 1; }
+message B { C c = 1; }
+message C { A a = 1; }
+`)
+	expectCycleError(t, err, "test.A")
+	if err != nil {
+		msg := err.Error()
+		for _, want := range []string{"test.B", "test.C"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("expected %q in cycle error, got: %s", want, msg)
+			}
+		}
+	}
+}
+
+// TestCycleCheck_OptionalSelfReferenceAllowed reproduces the canonical
+// linked-list shape from proto/basic/recursive.proto. `optional` makes the
+// field a `*LinkedList`, which has a fixed size in Go, so the cycle is broken
+// at the type level.
+func TestCycleCheck_OptionalSelfReferenceAllowed(t *testing.T) {
+	if err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message LinkedList {
+  int64 value = 1;
+  optional LinkedList next = 2;
+}
+`); err != nil {
+		t.Fatalf("expected no error for optional self-reference, got: %v", err)
+	}
+}
+
+// TestCycleCheck_RepeatedSelfReferenceAllowed pins the tree-via-slice shape.
+// `repeated TreeNode children` surfaces as `[]TreeNode`, whose element type
+// is `TreeNode` but the slice header itself has a fixed size, so the struct
+// is well-formed.
+func TestCycleCheck_RepeatedSelfReferenceAllowed(t *testing.T) {
+	if err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message TreeNode {
+  string label = 1;
+  repeated TreeNode children = 2;
+}
+`); err != nil {
+		t.Fatalf("expected no error for repeated self-reference, got: %v", err)
+	}
+}
+
+// TestCycleCheck_PointerOptionSelfReferenceAllowed verifies the explicit
+// opt-in via `(wiresmith.options.pointer) = true` also breaks the cycle.
+// Without this exception, users would be unable to express "recursive
+// message, no proto3-optional semantics" — only `optional` would work, and
+// `optional` carries presence semantics they may not want.
+func TestCycleCheck_PointerOptionSelfReferenceAllowed(t *testing.T) {
+	if err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+import "wiresmith/options.proto";
+message Node {
+  int64 value = 1;
+  Node next = 2 [(wiresmith.options.pointer) = true];
+}
+`); err != nil {
+		t.Fatalf("expected no error for pointer-option self-reference, got: %v", err)
+	}
+}
+
+// TestCycleCheck_OneofSelfReferenceAllowed verifies that a oneof variant
+// pointing back to the parent message does not trigger the cycle check.
+// Oneofs surface as a Go interface, breaking the size dependency.
+func TestCycleCheck_OneofSelfReferenceAllowed(t *testing.T) {
+	if err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message Box {
+  oneof choice {
+    Box inner = 1;
+    int32 leaf = 2;
+  }
+}
+`); err != nil {
+		t.Fatalf("expected no error for oneof self-reference, got: %v", err)
+	}
+}
+
+// TestCycleCheck_MapSelfReferenceAllowed verifies map value type pointing
+// back to the containing message is allowed. Maps surface as
+// `map[K]V` in Go — the map header is fixed-size and the value is stored
+// on the heap, so there's no size-recursion problem.
+func TestCycleCheck_MapSelfReferenceAllowed(t *testing.T) {
+	if err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message Tree {
+  string name = 1;
+  map<string, Tree> children = 2;
+}
+`); err != nil {
+		t.Fatalf("expected no error for map-self-reference, got: %v", err)
+	}
+}
+
+// TestCycleCheck_NoCycleHonoursAcyclicReferences confirms that ordinary
+// nested-but-acyclic message hierarchies aren't flagged. This is the
+// regression guard that protects every well-formed proto in the existing
+// gen/ tree — failing it would mean the cycle check is over-broad.
+func TestCycleCheck_NoCycleHonoursAcyclicReferences(t *testing.T) {
+	if err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message Inner { int32 x = 1; }
+message Outer { Inner i = 1; }
+`); err != nil {
+		t.Fatalf("expected no error for acyclic chain, got: %v", err)
+	}
+}
+
+// TestCycleCheck_OneEdgeBrokenAvoidsCycle tests the mixed case: a two-message
+// cycle where one direction is `optional`. The optional edge breaks the SCC
+// in the value-recursion graph even though the underlying message graph
+// still has a cycle. This is the smallest case proving the check correctly
+// excludes optional edges from the graph.
+func TestCycleCheck_OneEdgeBrokenAvoidsCycle(t *testing.T) {
+	if err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message A {
+  optional B b = 1;
+}
+message B {
+  A a = 1;
+}
+`); err != nil {
+		t.Fatalf("expected no error when one edge is optional, got: %v", err)
+	}
+}
+
+// TestCycleCheck_DisjointCyclesAllReported confirms that two independent
+// cycles in the same proto file both surface in a single error. Without
+// this, fixing one cycle would just unmask the next on the following run,
+// turning what should be one fix-up into several.
+func TestCycleCheck_DisjointCyclesAllReported(t *testing.T) {
+	err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message Loop1 { Loop1 self = 1; }
+message Loop2 { Loop2 self = 1; }
+`)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"test.Loop1", "test.Loop2"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("expected %q in error, got: %s", want, msg)
+		}
+	}
+}
+
+// TestCycleCheck_NestedMessageSelfReferenceRejected covers a self-loop on a
+// nested message type. forEachMessage walks nested-before-parent, so this
+// also confirms our message collection traverses into nested definitions.
+func TestCycleCheck_NestedMessageSelfReferenceRejected(t *testing.T) {
+	err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message Outer {
+  message Inner {
+    Inner child = 1;
+  }
+  Inner i = 1;
+}
+`)
+	expectCycleError(t, err, "test.Outer.Inner")
+}
+
+// TestCycleCheck_OneofAndSelfTogether documents that having BOTH a oneof
+// variant self-reference AND a direct value-typed self-reference still
+// fails: the cycle check considers only the direct value field, ignoring
+// the oneof. Without this, a user could accidentally add a non-oneof
+// recursive field next to the oneof and the broken struct would slip
+// through.
+func TestCycleCheck_OneofAndSelfTogether(t *testing.T) {
+	err := runGenerator(t, `
+syntax = "proto3";
+package test;
+option go_package = "wiresmith/gen/test/v1";
+message Tangle {
+  oneof choice {
+    Tangle inner = 1;
+    int32 leaf = 2;
+  }
+  Tangle direct = 3;
+}
+`)
+	expectCycleError(t, err, "test.Tangle.direct")
+}

--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -162,6 +162,9 @@ func (g *Generator) Generate(ctx context.Context) error {
 	if err := g.validatePointerOptions(results); err != nil {
 		return err
 	}
+	if err := g.validateNoValueCycles(results); err != nil {
+		return err
+	}
 
 	if err := g.collectGoPackages(results); err != nil {
 		return err


### PR DESCRIPTION
## Summary

Self-referencing messages without `optional` (e.g. `message Tree { Tree child = 1; }`) were silently emitted as recursively-sized Go structs (`type Tree struct { Child Tree }`), which `go vet` and `go build` both reject as "invalid recursive type". Closes [CR-4](https://github.com/grafana/wiresmith/issues?q=is%3Aopen+is%3Aissue+wiresmith-6ii).

This adds a Tarjan SCC over the value-type message-field graph as a planning-phase validation step, ignoring edges that already break recursion at the Go type level:

- `optional` (becomes `*T`)
- `repeated` (becomes `[]T`)
- `map<K, V>` (becomes `map[K]V`)
- `oneof` variants (interface-boxed)
- `(wiresmith.options.pointer) = true` (becomes `*T` / `[]*T`)

When a cycle is detected, the generator returns an actionable error naming every field in the cycle and listing the escape hatches.

Example output:

```
value-type message field cycle detected — generated Go would be a recursively-sized struct that does not compile.
Break the cycle by marking one of the fields below with `optional` ..., `[(wiresmith.options.pointer) = true]` ..., or by changing it to `repeated`, `map<>`, or a oneof variant:
  - test.A --(field "b")--> test.B --(field "a")--> test.A
  - test.Tree.child (type test.Tree)
```

## Test plan

- [x] `go test ./compiler/...` — all generator tests pass, including new dedicated cycle-check coverage
- [x] `make generate-ours` — checked-in `gen/` tree is byte-identical (no existing proto carries a value-type cycle)
- [x] `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn go test ./...` — full suite green
- [x] New tests cover: direct self-cycle, 2-message mutual recursion, 3-message cycle, disjoint cycles, nested-message self-reference, oneof + direct self-reference. Negative cases: `optional`, `repeated`, `map<>`, `oneof`, `(wiresmith.options.pointer) = true`, and a one-edge-broken mixed case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)