### PR TITLE
fix: nil-safe Size and Marshal* (wiresmith-2ma)

### DIFF
--- a/compiler/generator/emit_marshal.go
+++ b/compiler/generator/emit_marshal.go
@@ -15,6 +15,7 @@ func (fg *FileGenerator) emitMarshal(md protoreflect.MessageDescriptor) {
 
 	// Marshal allocates and returns the encoded bytes.
 	fmt.Fprintf(fg.body, "func (m *%s) Marshal() (dAtA []byte, err error) {\n", name)
+	fmt.Fprintf(fg.body, "\tif m == nil {\n\t\treturn nil, nil\n\t}\n")
 	fmt.Fprintf(fg.body, "\tsize := m.Size()\n")
 	fmt.Fprintf(fg.body, "\tdAtA = make([]byte, size)\n")
 	fmt.Fprintf(fg.body, "\tif size == 0 {\n\t\treturn dAtA, nil\n\t}\n")
@@ -25,6 +26,7 @@ func (fg *FileGenerator) emitMarshal(md protoreflect.MessageDescriptor) {
 
 	// MarshalTo writes the message into dAtA.
 	fmt.Fprintf(fg.body, "func (m *%s) MarshalTo(dAtA []byte) (int, error) {\n", name)
+	fmt.Fprintf(fg.body, "\tif m == nil {\n\t\treturn 0, nil\n\t}\n")
 	fmt.Fprintf(fg.body, "\tsize := m.Size()\n")
 	fmt.Fprintf(fg.body, "\treturn m.MarshalToSizedBuffer(dAtA[:size])\n")
 	fmt.Fprintf(fg.body, "}\n\n")
@@ -32,6 +34,7 @@ func (fg *FileGenerator) emitMarshal(md protoreflect.MessageDescriptor) {
 	// MarshalToSizedBuffer writes the message backwards into dAtA.
 	// Returns the number of bytes written.
 	fmt.Fprintf(fg.body, "func (m *%s) MarshalToSizedBuffer(dAtA []byte) (int, error) {\n", name)
+	fmt.Fprintf(fg.body, "\tif m == nil {\n\t\treturn 0, nil\n\t}\n")
 	fmt.Fprintf(fg.body, "\ti := len(dAtA)\n")
 
 	// Collect fields sorted by number descending for reverse-write.

--- a/compiler/generator/emit_size.go
+++ b/compiler/generator/emit_size.go
@@ -13,6 +13,7 @@ func (fg *FileGenerator) emitSize(md protoreflect.MessageDescriptor) {
 	fg.imports.addImport("google.golang.org/protobuf/encoding/protowire", "")
 
 	fmt.Fprintf(fg.body, "func (m *%s) Size() int {\n", name)
+	fmt.Fprintf(fg.body, "\tif m == nil {\n\t\treturn 0\n\t}\n")
 	fmt.Fprintf(fg.body, "\tvar n int\n")
 
 	pm := fg.presenceMap(md)

--- a/gen/basic/enum/v1/enum.pb.go
+++ b/gen/basic/enum/v1/enum.pb.go
@@ -238,6 +238,9 @@ func (m *EnumContainer) GetSignedMap() map[string]SignedEnum {
 }
 
 func (m *WithNestedEnum) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.Priority != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.Priority))
@@ -256,6 +259,9 @@ func (m *WithNestedEnum) Size() int {
 }
 
 func (m *EnumContainer) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.Aliased != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.Aliased))
@@ -283,6 +289,9 @@ func (m *EnumContainer) Size() int {
 }
 
 func (m *WithNestedEnum) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -296,11 +305,17 @@ func (m *WithNestedEnum) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *WithNestedEnum) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *WithNestedEnum) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Name) > 0 {
 		i -= len(m.Name)
@@ -328,6 +343,9 @@ func (m *WithNestedEnum) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *EnumContainer) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -341,11 +359,17 @@ func (m *EnumContainer) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *EnumContainer) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *EnumContainer) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for k, v := range m.SignedMap {
 		baseI := i

--- a/gen/basic/maps/v1/maps.pb.go
+++ b/gen/basic/maps/v1/maps.pb.go
@@ -118,6 +118,9 @@ func (m *Inner) GetData() []byte {
 }
 
 func (m *MapBench) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for k, v := range m.StringMap {
 		entrySize := 0
@@ -142,6 +145,9 @@ func (m *MapBench) Size() int {
 }
 
 func (m *Inner) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Name) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Name))) + len(m.Name)
@@ -156,6 +162,9 @@ func (m *Inner) Size() int {
 }
 
 func (m *MapBench) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -169,11 +178,17 @@ func (m *MapBench) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *MapBench) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MapBench) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for k, v := range m.MessageMap {
 		baseI := i
@@ -226,6 +241,9 @@ func (m *MapBench) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Inner) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -239,11 +257,17 @@ func (m *Inner) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Inner) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Inner) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Data) > 0 {
 		i -= len(m.Data)

--- a/gen/basic/nesting/v1/nesting.pb.go
+++ b/gen/basic/nesting/v1/nesting.pb.go
@@ -282,6 +282,9 @@ func (m *CrossRef) GetTag() string {
 }
 
 func (m *Level0_Level1_Level2_Level3) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.DeepValue) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.DeepValue))) + len(m.DeepValue)
@@ -293,6 +296,9 @@ func (m *Level0_Level1_Level2_Level3) Size() int {
 }
 
 func (m *Level0_Level1_Level2) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Child.Size()
@@ -309,6 +315,9 @@ func (m *Level0_Level1_Level2) Size() int {
 }
 
 func (m *Level0_Level1) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Child.Size()
@@ -329,6 +338,9 @@ func (m *Level0_Level1) Size() int {
 }
 
 func (m *Level0) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Child.Size()
@@ -345,6 +357,9 @@ func (m *Level0) Size() int {
 }
 
 func (m *CrossRef) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.NestedRef.Size()
@@ -369,6 +384,9 @@ func (m *CrossRef) Size() int {
 }
 
 func (m *Level0_Level1_Level2_Level3) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -382,11 +400,17 @@ func (m *Level0_Level1_Level2_Level3) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Level0_Level1_Level2_Level3) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Level0_Level1_Level2_Level3) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Depth != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Depth))
@@ -404,6 +428,9 @@ func (m *Level0_Level1_Level2_Level3) MarshalToSizedBuffer(dAtA []byte) (int, er
 }
 
 func (m *Level0_Level1_Level2) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -417,11 +444,17 @@ func (m *Level0_Level1_Level2) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Level0_Level1_Level2) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Level0_Level1_Level2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Value) > 0 {
 		i -= len(m.Value)
@@ -451,6 +484,9 @@ func (m *Level0_Level1_Level2) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Level0_Level1) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -464,11 +500,17 @@ func (m *Level0_Level1) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Level0_Level1) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Level0_Level1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Value) > 0 {
 		i -= len(m.Value)
@@ -508,6 +550,9 @@ func (m *Level0_Level1) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Level0) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -521,11 +566,17 @@ func (m *Level0) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Level0) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Level0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Label) > 0 {
 		i -= len(m.Label)
@@ -555,6 +606,9 @@ func (m *Level0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *CrossRef) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -568,11 +622,17 @@ func (m *CrossRef) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *CrossRef) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *CrossRef) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Tag) > 0 {
 		i -= len(m.Tag)

--- a/gen/basic/numeric/v1/numeric.pb.go
+++ b/gen/basic/numeric/v1/numeric.pb.go
@@ -1351,6 +1351,9 @@ func (m *WideFields) GetF70() bool {
 }
 
 func (m *UnpackedScalars) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	n += len(m.FieldDouble) * 9
 	n += len(m.FieldFloat) * 5
@@ -1381,6 +1384,9 @@ func (m *UnpackedScalars) Size() int {
 }
 
 func (m *MixedModifiers) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.RegularInt != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.RegularInt))
@@ -1427,6 +1433,9 @@ func (m *MixedModifiers) Size() int {
 }
 
 func (m *WideFields) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.F1) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.F1))) + len(m.F1)
@@ -1642,6 +1651,9 @@ func (m *WideFields) Size() int {
 }
 
 func (m *UnpackedScalars) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1655,11 +1667,17 @@ func (m *UnpackedScalars) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *UnpackedScalars) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *UnpackedScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.FieldBool) - 1; iNdEx >= 0; iNdEx-- {
 		i--
@@ -1741,6 +1759,9 @@ func (m *UnpackedScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *MixedModifiers) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1754,11 +1775,17 @@ func (m *MixedModifiers) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *MixedModifiers) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MixedModifiers) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.RepeatedBytes) - 1; iNdEx >= 0; iNdEx-- {
 		i -= len(m.RepeatedBytes[iNdEx])
@@ -1847,6 +1874,9 @@ func (m *MixedModifiers) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *WideFields) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1860,11 +1890,17 @@ func (m *WideFields) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *WideFields) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *WideFields) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.F70 {
 		i--

--- a/gen/basic/oneof/v1/oneof.pb.go
+++ b/gen/basic/oneof/v1/oneof.pb.go
@@ -423,6 +423,9 @@ func (m *OneofPlusEverything) GetStructured() *Payload {
 }
 
 func (m *Payload) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Data) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Data))) + len(m.Data)
@@ -434,6 +437,9 @@ func (m *Payload) Size() int {
 }
 
 func (m *MultiOneof) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	switch v := m.Primary.(type) {
 	case *MultiOneof_StrVal:
@@ -463,6 +469,9 @@ func (m *MultiOneof) Size() int {
 }
 
 func (m *OneofWithTypes) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	switch v := m.Value.(type) {
 	case *OneofWithTypes_StrVal:
@@ -480,6 +489,9 @@ func (m *OneofWithTypes) Size() int {
 }
 
 func (m *OneofPlusEverything) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Name) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Name))) + len(m.Name)
@@ -515,6 +527,9 @@ func (m *OneofPlusEverything) Size() int {
 }
 
 func (m *Payload) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -528,11 +543,17 @@ func (m *Payload) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Payload) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Payload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Number != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Number))
@@ -550,6 +571,9 @@ func (m *Payload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *MultiOneof) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -563,11 +587,17 @@ func (m *MultiOneof) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *MultiOneof) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MultiOneof) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.RegularField) > 0 {
 		i -= len(m.RegularField)
@@ -623,6 +653,9 @@ func (m *MultiOneof) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *OneofWithTypes) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -636,11 +669,17 @@ func (m *OneofWithTypes) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *OneofWithTypes) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *OneofWithTypes) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	switch v := m.Value.(type) {
 	case *OneofWithTypes_EnumVal:
@@ -671,6 +710,9 @@ func (m *OneofWithTypes) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *OneofPlusEverything) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -684,11 +726,17 @@ func (m *OneofPlusEverything) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *OneofPlusEverything) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *OneofPlusEverything) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	switch v := m.Payload.(type) {
 	case *OneofPlusEverything_Structured:

--- a/gen/basic/pointer/v1/pointer.pb.go
+++ b/gen/basic/pointer/v1/pointer.pb.go
@@ -135,6 +135,9 @@ func (m *PointerHolder) GetTail() *Leaf {
 }
 
 func (m *Leaf) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.Id != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.Id))
@@ -146,6 +149,9 @@ func (m *Leaf) Size() int {
 }
 
 func (m *PointerHolder) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Name) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Name))) + len(m.Name)
@@ -173,6 +179,9 @@ func (m *PointerHolder) Size() int {
 }
 
 func (m *Leaf) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -186,11 +195,17 @@ func (m *Leaf) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Leaf) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Leaf) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Name) > 0 {
 		i -= len(m.Name)
@@ -208,6 +223,9 @@ func (m *Leaf) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *PointerHolder) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -221,11 +239,17 @@ func (m *PointerHolder) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *PointerHolder) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *PointerHolder) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	{
 		size, err := m.Tail.MarshalToSizedBuffer(dAtA[:i])

--- a/gen/basic/recursive/v1/recursive.pb.go
+++ b/gen/basic/recursive/v1/recursive.pb.go
@@ -206,6 +206,9 @@ func (m *NodeB) GetParent() *NodeA {
 }
 
 func (m *LinkedList) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.Value != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.Value))
@@ -218,6 +221,9 @@ func (m *LinkedList) Size() int {
 }
 
 func (m *TreeNode) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Label) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Label))) + len(m.Label)
@@ -233,6 +239,9 @@ func (m *TreeNode) Size() int {
 }
 
 func (m *NodeA) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Name) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Name))) + len(m.Name)
@@ -249,6 +258,9 @@ func (m *NodeA) Size() int {
 }
 
 func (m *NodeB) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.Id != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.Id))
@@ -261,6 +273,9 @@ func (m *NodeB) Size() int {
 }
 
 func (m *LinkedList) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -274,11 +289,17 @@ func (m *LinkedList) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *LinkedList) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *LinkedList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Next != nil {
 		size, err := (*m.Next).MarshalToSizedBuffer(dAtA[:i])
@@ -299,6 +320,9 @@ func (m *LinkedList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *TreeNode) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -312,11 +336,17 @@ func (m *TreeNode) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TreeNode) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *TreeNode) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.Children) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.Children[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -344,6 +374,9 @@ func (m *TreeNode) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *NodeA) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -357,11 +390,17 @@ func (m *NodeA) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *NodeA) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *NodeA) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.Peers) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.Peers[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -394,6 +433,9 @@ func (m *NodeA) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *NodeB) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -407,11 +449,17 @@ func (m *NodeB) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *NodeB) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *NodeB) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Parent != nil {
 		size, err := (*m.Parent).MarshalToSizedBuffer(dAtA[:i])

--- a/gen/otlp/common/v1/common.pb.go
+++ b/gen/otlp/common/v1/common.pb.go
@@ -470,6 +470,9 @@ func (m *EntityRef) GetDescriptionKeys() []string {
 }
 
 func (m *AnyValue) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	switch v := m.Value.(type) {
 	case *AnyValue_StringValue:
@@ -499,6 +502,9 @@ func (m *AnyValue) Size() int {
 }
 
 func (m *ArrayValue) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.Values {
 		s := m.Values[i].Size()
@@ -508,6 +514,9 @@ func (m *ArrayValue) Size() int {
 }
 
 func (m *KeyValueList) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.Values {
 		s := m.Values[i].Size()
@@ -517,6 +526,9 @@ func (m *KeyValueList) Size() int {
 }
 
 func (m *KeyValue) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Key) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Key))) + len(m.Key)
@@ -536,6 +548,9 @@ func (m *KeyValue) Size() int {
 }
 
 func (m *InstrumentationScope) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Name) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Name))) + len(m.Name)
@@ -554,6 +569,9 @@ func (m *InstrumentationScope) Size() int {
 }
 
 func (m *EntityRef) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.SchemaUrl) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.SchemaUrl))) + len(m.SchemaUrl)
@@ -571,6 +589,9 @@ func (m *EntityRef) Size() int {
 }
 
 func (m *AnyValue) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -584,11 +605,17 @@ func (m *AnyValue) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AnyValue) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *AnyValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	switch v := m.Value.(type) {
 	case *AnyValue_StringValueStrindex:
@@ -648,6 +675,9 @@ func (m *AnyValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ArrayValue) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -661,11 +691,17 @@ func (m *ArrayValue) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ArrayValue) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ArrayValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.Values) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.Values[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -681,6 +717,9 @@ func (m *ArrayValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *KeyValueList) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -694,11 +733,17 @@ func (m *KeyValueList) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *KeyValueList) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *KeyValueList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.Values) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.Values[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -714,6 +759,9 @@ func (m *KeyValueList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *KeyValue) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -727,11 +775,17 @@ func (m *KeyValue) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *KeyValue) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *KeyValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.KeyStrindex != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.KeyStrindex))
@@ -766,6 +820,9 @@ func (m *KeyValue) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *InstrumentationScope) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -779,11 +836,17 @@ func (m *InstrumentationScope) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *InstrumentationScope) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *InstrumentationScope) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.DroppedAttributesCount != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DroppedAttributesCount))
@@ -818,6 +881,9 @@ func (m *InstrumentationScope) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *EntityRef) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -831,11 +897,17 @@ func (m *EntityRef) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *EntityRef) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *EntityRef) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.DescriptionKeys) - 1; iNdEx >= 0; iNdEx-- {
 		i -= len(m.DescriptionKeys[iNdEx])

--- a/gen/otlp/logs/v1/logs.pb.go
+++ b/gen/otlp/logs/v1/logs.pb.go
@@ -566,6 +566,9 @@ func (m *LogRecord) GetEventName() string {
 }
 
 func (m *LogsData) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.ResourceLogs {
 		s := m.ResourceLogs[i].Size()
@@ -575,6 +578,9 @@ func (m *LogsData) Size() int {
 }
 
 func (m *ResourceLogs) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Resource.Size()
@@ -595,6 +601,9 @@ func (m *ResourceLogs) Size() int {
 }
 
 func (m *ScopeLogs) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Scope.Size()
@@ -615,6 +624,9 @@ func (m *ScopeLogs) Size() int {
 }
 
 func (m *LogRecord) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.TimeUnixNano != 0 {
 		n += 9
@@ -659,6 +671,9 @@ func (m *LogRecord) Size() int {
 }
 
 func (m *LogsData) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -672,11 +687,17 @@ func (m *LogsData) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *LogsData) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *LogsData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.ResourceLogs) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.ResourceLogs[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -692,6 +713,9 @@ func (m *LogsData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ResourceLogs) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -705,11 +729,17 @@ func (m *ResourceLogs) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ResourceLogs) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ResourceLogs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.SchemaUrl) > 0 {
 		i -= len(m.SchemaUrl)
@@ -749,6 +779,9 @@ func (m *ResourceLogs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ScopeLogs) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -762,11 +795,17 @@ func (m *ScopeLogs) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ScopeLogs) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ScopeLogs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.SchemaUrl) > 0 {
 		i -= len(m.SchemaUrl)
@@ -806,6 +845,9 @@ func (m *ScopeLogs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *LogRecord) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -819,11 +861,17 @@ func (m *LogRecord) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *LogRecord) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *LogRecord) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.EventName) > 0 {
 		i -= len(m.EventName)

--- a/gen/otlp/metrics/v1/metrics.pb.go
+++ b/gen/otlp/metrics/v1/metrics.pb.go
@@ -1804,6 +1804,9 @@ func (m *Exemplar) GetTraceId() []byte {
 }
 
 func (m *MetricsData) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.ResourceMetrics {
 		s := m.ResourceMetrics[i].Size()
@@ -1813,6 +1816,9 @@ func (m *MetricsData) Size() int {
 }
 
 func (m *ResourceMetrics) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Resource.Size()
@@ -1833,6 +1839,9 @@ func (m *ResourceMetrics) Size() int {
 }
 
 func (m *ScopeMetrics) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Scope.Size()
@@ -1853,6 +1862,9 @@ func (m *ScopeMetrics) Size() int {
 }
 
 func (m *Metric) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Name) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Name))) + len(m.Name)
@@ -1888,6 +1900,9 @@ func (m *Metric) Size() int {
 }
 
 func (m *Gauge) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.DataPoints {
 		s := m.DataPoints[i].Size()
@@ -1897,6 +1912,9 @@ func (m *Gauge) Size() int {
 }
 
 func (m *Sum) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.DataPoints {
 		s := m.DataPoints[i].Size()
@@ -1912,6 +1930,9 @@ func (m *Sum) Size() int {
 }
 
 func (m *Histogram) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.DataPoints {
 		s := m.DataPoints[i].Size()
@@ -1924,6 +1945,9 @@ func (m *Histogram) Size() int {
 }
 
 func (m *ExponentialHistogram) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.DataPoints {
 		s := m.DataPoints[i].Size()
@@ -1936,6 +1960,9 @@ func (m *ExponentialHistogram) Size() int {
 }
 
 func (m *Summary) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.DataPoints {
 		s := m.DataPoints[i].Size()
@@ -1945,6 +1972,9 @@ func (m *Summary) Size() int {
 }
 
 func (m *NumberDataPoint) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.Attributes {
 		s := m.Attributes[i].Size()
@@ -1975,6 +2005,9 @@ func (m *NumberDataPoint) Size() int {
 }
 
 func (m *HistogramDataPoint) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.Attributes {
 		s := m.Attributes[i].Size()
@@ -2017,6 +2050,9 @@ func (m *HistogramDataPoint) Size() int {
 }
 
 func (m *ExponentialHistogramDataPoint_Buckets) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.Offset != 0 {
 		n += 1 + protowire.SizeVarint(protowire.EncodeZigZag(int64(m.Offset)))
@@ -2032,6 +2068,9 @@ func (m *ExponentialHistogramDataPoint_Buckets) Size() int {
 }
 
 func (m *ExponentialHistogramDataPoint) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.Attributes {
 		s := m.Attributes[i].Size()
@@ -2091,6 +2130,9 @@ func (m *ExponentialHistogramDataPoint) Size() int {
 }
 
 func (m *SummaryDataPoint_ValueAtQuantile) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if math.Float64bits(m.Quantile) != 0 {
 		n += 9
@@ -2102,6 +2144,9 @@ func (m *SummaryDataPoint_ValueAtQuantile) Size() int {
 }
 
 func (m *SummaryDataPoint) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.Attributes {
 		s := m.Attributes[i].Size()
@@ -2130,6 +2175,9 @@ func (m *SummaryDataPoint) Size() int {
 }
 
 func (m *Exemplar) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.FilteredAttributes {
 		s := m.FilteredAttributes[i].Size()
@@ -2156,6 +2204,9 @@ func (m *Exemplar) Size() int {
 }
 
 func (m *MetricsData) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2169,11 +2220,17 @@ func (m *MetricsData) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *MetricsData) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MetricsData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.ResourceMetrics) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.ResourceMetrics[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -2189,6 +2246,9 @@ func (m *MetricsData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ResourceMetrics) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2202,11 +2262,17 @@ func (m *ResourceMetrics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ResourceMetrics) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ResourceMetrics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.SchemaUrl) > 0 {
 		i -= len(m.SchemaUrl)
@@ -2246,6 +2312,9 @@ func (m *ResourceMetrics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ScopeMetrics) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2259,11 +2328,17 @@ func (m *ScopeMetrics) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ScopeMetrics) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ScopeMetrics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.SchemaUrl) > 0 {
 		i -= len(m.SchemaUrl)
@@ -2303,6 +2378,9 @@ func (m *ScopeMetrics) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Metric) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2316,11 +2394,17 @@ func (m *Metric) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Metric) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Metric) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.Metadata) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.Metadata[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -2404,6 +2488,9 @@ func (m *Metric) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Gauge) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2417,11 +2504,17 @@ func (m *Gauge) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Gauge) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Gauge) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.DataPoints) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.DataPoints[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -2437,6 +2530,9 @@ func (m *Gauge) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Sum) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2450,11 +2546,17 @@ func (m *Sum) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Sum) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Sum) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.IsMonotonic {
 		i--
@@ -2485,6 +2587,9 @@ func (m *Sum) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Histogram) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2498,11 +2603,17 @@ func (m *Histogram) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Histogram) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Histogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.AggregationTemporality != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.AggregationTemporality))
@@ -2523,6 +2634,9 @@ func (m *Histogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ExponentialHistogram) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2536,11 +2650,17 @@ func (m *ExponentialHistogram) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ExponentialHistogram) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ExponentialHistogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.AggregationTemporality != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.AggregationTemporality))
@@ -2561,6 +2681,9 @@ func (m *ExponentialHistogram) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Summary) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2574,11 +2697,17 @@ func (m *Summary) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Summary) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Summary) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.DataPoints) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.DataPoints[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -2594,6 +2723,9 @@ func (m *Summary) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *NumberDataPoint) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2607,11 +2739,17 @@ func (m *NumberDataPoint) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *NumberDataPoint) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *NumberDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Flags != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Flags))
@@ -2666,6 +2804,9 @@ func (m *NumberDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *HistogramDataPoint) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2679,11 +2820,17 @@ func (m *HistogramDataPoint) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *HistogramDataPoint) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *HistogramDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Max != nil {
 		i -= 8
@@ -2768,6 +2915,9 @@ func (m *HistogramDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ExponentialHistogramDataPoint_Buckets) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2781,11 +2931,17 @@ func (m *ExponentialHistogramDataPoint_Buckets) Marshal() (dAtA []byte, err erro
 }
 
 func (m *ExponentialHistogramDataPoint_Buckets) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ExponentialHistogramDataPoint_Buckets) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.BucketCounts) > 0 {
 		var j int
@@ -2806,6 +2962,9 @@ func (m *ExponentialHistogramDataPoint_Buckets) MarshalToSizedBuffer(dAtA []byte
 }
 
 func (m *ExponentialHistogramDataPoint) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2819,11 +2978,17 @@ func (m *ExponentialHistogramDataPoint) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ExponentialHistogramDataPoint) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ExponentialHistogramDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if v := math.Float64bits(m.ZeroThreshold); v != 0 {
 		i -= 8
@@ -2941,6 +3106,9 @@ func (m *ExponentialHistogramDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, 
 }
 
 func (m *SummaryDataPoint_ValueAtQuantile) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2954,11 +3122,17 @@ func (m *SummaryDataPoint_ValueAtQuantile) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *SummaryDataPoint_ValueAtQuantile) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *SummaryDataPoint_ValueAtQuantile) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if v := math.Float64bits(m.Value); v != 0 {
 		i -= 8
@@ -2976,6 +3150,9 @@ func (m *SummaryDataPoint_ValueAtQuantile) MarshalToSizedBuffer(dAtA []byte) (in
 }
 
 func (m *SummaryDataPoint) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2989,11 +3166,17 @@ func (m *SummaryDataPoint) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *SummaryDataPoint) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *SummaryDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Flags != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Flags))
@@ -3048,6 +3231,9 @@ func (m *SummaryDataPoint) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Exemplar) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -3061,11 +3247,17 @@ func (m *Exemplar) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Exemplar) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Exemplar) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.FilteredAttributes) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.FilteredAttributes[iNdEx].MarshalToSizedBuffer(dAtA[:i])

--- a/gen/otlp/profiles/v1development/profiles.pb.go
+++ b/gen/otlp/profiles/v1development/profiles.pb.go
@@ -1249,6 +1249,9 @@ func (m *KeyValueAndUnit) GetUnitStrindex() int32 {
 }
 
 func (m *ProfilesDictionary) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.MappingTable {
 		s := m.MappingTable[i].Size()
@@ -1281,6 +1284,9 @@ func (m *ProfilesDictionary) Size() int {
 }
 
 func (m *ProfilesData) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.ResourceProfiles {
 		s := m.ResourceProfiles[i].Size()
@@ -1298,6 +1304,9 @@ func (m *ProfilesData) Size() int {
 }
 
 func (m *ResourceProfiles) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Resource.Size()
@@ -1318,6 +1327,9 @@ func (m *ResourceProfiles) Size() int {
 }
 
 func (m *ScopeProfiles) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Scope.Size()
@@ -1338,6 +1350,9 @@ func (m *ScopeProfiles) Size() int {
 }
 
 func (m *Profile) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.SampleType.Size()
@@ -1391,6 +1406,9 @@ func (m *Profile) Size() int {
 }
 
 func (m *Link) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.TraceId) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.TraceId))) + len(m.TraceId)
@@ -1402,6 +1420,9 @@ func (m *Link) Size() int {
 }
 
 func (m *ValueType) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.TypeStrindex != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.TypeStrindex))
@@ -1413,6 +1434,9 @@ func (m *ValueType) Size() int {
 }
 
 func (m *Sample) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.StackIndex != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.StackIndex))
@@ -1442,6 +1466,9 @@ func (m *Sample) Size() int {
 }
 
 func (m *Mapping) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.MemoryStart != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.MemoryStart))
@@ -1466,6 +1493,9 @@ func (m *Mapping) Size() int {
 }
 
 func (m *Stack) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.LocationIndices) > 0 {
 		var dataLen int
@@ -1478,6 +1508,9 @@ func (m *Stack) Size() int {
 }
 
 func (m *Location) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.MappingIndex != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.MappingIndex))
@@ -1500,6 +1533,9 @@ func (m *Location) Size() int {
 }
 
 func (m *Line) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.FunctionIndex != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.FunctionIndex))
@@ -1514,6 +1550,9 @@ func (m *Line) Size() int {
 }
 
 func (m *Function) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.NameStrindex != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.NameStrindex))
@@ -1531,6 +1570,9 @@ func (m *Function) Size() int {
 }
 
 func (m *KeyValueAndUnit) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.KeyStrindex != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.KeyStrindex))
@@ -1550,6 +1592,9 @@ func (m *KeyValueAndUnit) Size() int {
 }
 
 func (m *ProfilesDictionary) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1563,11 +1608,17 @@ func (m *ProfilesDictionary) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ProfilesDictionary) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ProfilesDictionary) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.StackTable) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.StackTable[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -1640,6 +1691,9 @@ func (m *ProfilesDictionary) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ProfilesData) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1653,11 +1707,17 @@ func (m *ProfilesData) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ProfilesData) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ProfilesData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	{
 		size, err := m.Dictionary.MarshalToSizedBuffer(dAtA[:i])
@@ -1690,6 +1750,9 @@ func (m *ProfilesData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ResourceProfiles) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1703,11 +1766,17 @@ func (m *ResourceProfiles) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ResourceProfiles) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ResourceProfiles) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.SchemaUrl) > 0 {
 		i -= len(m.SchemaUrl)
@@ -1747,6 +1816,9 @@ func (m *ResourceProfiles) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ScopeProfiles) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1760,11 +1832,17 @@ func (m *ScopeProfiles) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ScopeProfiles) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ScopeProfiles) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.SchemaUrl) > 0 {
 		i -= len(m.SchemaUrl)
@@ -1804,6 +1882,9 @@ func (m *ScopeProfiles) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Profile) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1817,11 +1898,17 @@ func (m *Profile) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Profile) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Profile) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.AttributeIndices) > 0 {
 		var j int
@@ -1923,6 +2010,9 @@ func (m *Profile) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Link) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1936,11 +2026,17 @@ func (m *Link) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Link) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Link) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.SpanId) > 0 {
 		i -= len(m.SpanId)
@@ -1960,6 +2056,9 @@ func (m *Link) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ValueType) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1973,11 +2072,17 @@ func (m *ValueType) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ValueType) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ValueType) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.UnitStrindex != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnitStrindex))
@@ -1993,6 +2098,9 @@ func (m *ValueType) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Sample) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2006,11 +2114,17 @@ func (m *Sample) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Sample) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Sample) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.TimestampsUnixNano) > 0 {
 		for iNdEx := len(m.TimestampsUnixNano) - 1; iNdEx >= 0; iNdEx-- {
@@ -2055,6 +2169,9 @@ func (m *Sample) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Mapping) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2068,11 +2185,17 @@ func (m *Mapping) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Mapping) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Mapping) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.AttributeIndices) > 0 {
 		var j int
@@ -2108,6 +2231,9 @@ func (m *Mapping) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Stack) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2121,11 +2247,17 @@ func (m *Stack) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Stack) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Stack) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.LocationIndices) > 0 {
 		var j int
@@ -2141,6 +2273,9 @@ func (m *Stack) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Location) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2154,11 +2289,17 @@ func (m *Location) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Location) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Location) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.AttributeIndices) > 0 {
 		var j int
@@ -2194,6 +2335,9 @@ func (m *Location) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Line) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2207,11 +2351,17 @@ func (m *Line) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Line) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Line) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Column != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Column))
@@ -2232,6 +2382,9 @@ func (m *Line) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Function) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2245,11 +2398,17 @@ func (m *Function) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Function) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Function) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.StartLine != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.StartLine))
@@ -2275,6 +2434,9 @@ func (m *Function) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *KeyValueAndUnit) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2288,11 +2450,17 @@ func (m *KeyValueAndUnit) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *KeyValueAndUnit) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *KeyValueAndUnit) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.UnitStrindex != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.UnitStrindex))

--- a/gen/otlp/resource/v1/resource.pb.go
+++ b/gen/otlp/resource/v1/resource.pb.go
@@ -75,6 +75,9 @@ func (m *Resource) GetEntityRefs() []commonv1.EntityRef {
 }
 
 func (m *Resource) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.Attributes {
 		s := m.Attributes[i].Size()
@@ -91,6 +94,9 @@ func (m *Resource) Size() int {
 }
 
 func (m *Resource) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -104,11 +110,17 @@ func (m *Resource) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Resource) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Resource) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.EntityRefs) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.EntityRefs[iNdEx].MarshalToSizedBuffer(dAtA[:i])

--- a/gen/otlp/trace/v1/trace.pb.go
+++ b/gen/otlp/trace/v1/trace.pb.go
@@ -924,6 +924,9 @@ func (m *Status) GetCode() Status_StatusCode {
 }
 
 func (m *TracesData) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for i := range m.ResourceSpans {
 		s := m.ResourceSpans[i].Size()
@@ -933,6 +936,9 @@ func (m *TracesData) Size() int {
 }
 
 func (m *ResourceSpans) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Resource.Size()
@@ -953,6 +959,9 @@ func (m *ResourceSpans) Size() int {
 }
 
 func (m *ScopeSpans) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Scope.Size()
@@ -973,6 +982,9 @@ func (m *ScopeSpans) Size() int {
 }
 
 func (m *Span_Event) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.TimeUnixNano != 0 {
 		n += 9
@@ -991,6 +1003,9 @@ func (m *Span_Event) Size() int {
 }
 
 func (m *Span_Link) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.TraceId) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.TraceId))) + len(m.TraceId)
@@ -1015,6 +1030,9 @@ func (m *Span_Link) Size() int {
 }
 
 func (m *Span) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.TraceId) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.TraceId))) + len(m.TraceId)
@@ -1076,6 +1094,9 @@ func (m *Span) Size() int {
 }
 
 func (m *Status) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Message) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Message))) + len(m.Message)
@@ -1087,6 +1108,9 @@ func (m *Status) Size() int {
 }
 
 func (m *TracesData) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1100,11 +1124,17 @@ func (m *TracesData) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TracesData) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *TracesData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.ResourceSpans) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.ResourceSpans[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -1120,6 +1150,9 @@ func (m *TracesData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ResourceSpans) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1133,11 +1166,17 @@ func (m *ResourceSpans) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ResourceSpans) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ResourceSpans) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.SchemaUrl) > 0 {
 		i -= len(m.SchemaUrl)
@@ -1177,6 +1216,9 @@ func (m *ResourceSpans) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ScopeSpans) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1190,11 +1232,17 @@ func (m *ScopeSpans) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ScopeSpans) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ScopeSpans) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.SchemaUrl) > 0 {
 		i -= len(m.SchemaUrl)
@@ -1234,6 +1282,9 @@ func (m *ScopeSpans) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Span_Event) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1247,11 +1298,17 @@ func (m *Span_Event) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Span_Event) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Span_Event) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.DroppedAttributesCount != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.DroppedAttributesCount))
@@ -1285,6 +1342,9 @@ func (m *Span_Event) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Span_Link) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1298,11 +1358,17 @@ func (m *Span_Link) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Span_Link) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Span_Link) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Flags != 0 {
 		i -= 4
@@ -1350,6 +1416,9 @@ func (m *Span_Link) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Span) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1363,11 +1432,17 @@ func (m *Span) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Span) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Span) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Flags != 0 {
 		i -= 4
@@ -1495,6 +1570,9 @@ func (m *Span) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Status) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1508,11 +1586,17 @@ func (m *Status) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Status) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Status) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Code != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Code))

--- a/gen/protobuf_test_messages/proto3/test_messages_proto3.pb.go
+++ b/gen/protobuf_test_messages/proto3/test_messages_proto3.pb.go
@@ -1486,6 +1486,9 @@ func (m *ForeignMessage) GetC() int32 {
 }
 
 func (m *TestAllTypesProto3_NestedMessage) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.A != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.A))
@@ -1494,6 +1497,9 @@ func (m *TestAllTypesProto3_NestedMessage) Size() int {
 }
 
 func (m *TestAllTypesProto3) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.OptionalInt32 != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.OptionalInt32))
@@ -1977,6 +1983,9 @@ func (m *TestAllTypesProto3) Size() int {
 }
 
 func (m *ForeignMessage) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.C != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.C))
@@ -1985,16 +1994,25 @@ func (m *ForeignMessage) Size() int {
 }
 
 func (m *NullHypothesisProto3) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	return n
 }
 
 func (m *EnumOnlyProto3) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	return n
 }
 
 func (m *TestAllTypesProto3_NestedMessage) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2008,11 +2026,17 @@ func (m *TestAllTypesProto3_NestedMessage) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TestAllTypesProto3_NestedMessage) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *TestAllTypesProto3_NestedMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.A != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.A))
@@ -2023,6 +2047,9 @@ func (m *TestAllTypesProto3_NestedMessage) MarshalToSizedBuffer(dAtA []byte) (in
 }
 
 func (m *TestAllTypesProto3) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2036,11 +2063,17 @@ func (m *TestAllTypesProto3) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TestAllTypesProto3) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *TestAllTypesProto3) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.FieldName18 != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.FieldName18))
@@ -3235,6 +3268,9 @@ func (m *TestAllTypesProto3) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ForeignMessage) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -3248,11 +3284,17 @@ func (m *ForeignMessage) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ForeignMessage) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ForeignMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.C != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.C))
@@ -3263,6 +3305,9 @@ func (m *ForeignMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *NullHypothesisProto3) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -3276,16 +3321,25 @@ func (m *NullHypothesisProto3) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *NullHypothesisProto3) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *NullHypothesisProto3) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	return len(dAtA) - i, nil
 }
 
 func (m *EnumOnlyProto3) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -3299,11 +3353,17 @@ func (m *EnumOnlyProto3) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *EnumOnlyProto3) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *EnumOnlyProto3) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	return len(dAtA) - i, nil
 }

--- a/gen/test/kitchensink/v1/kitchen_sink.pb.go
+++ b/gen/test/kitchensink/v1/kitchen_sink.pb.go
@@ -1395,6 +1395,9 @@ func (m *AllMaps) GetMapStringEnum() map[string]Color {
 }
 
 func (m *AllScalars) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if math.Float64bits(m.FieldDouble) != 0 {
 		n += 9
@@ -1445,6 +1448,9 @@ func (m *AllScalars) Size() int {
 }
 
 func (m *AllOptionalScalars) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.FieldDouble != nil {
 		n += 9
@@ -1495,6 +1501,9 @@ func (m *AllOptionalScalars) Size() int {
 }
 
 func (m *AllRepeatedScalars) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.FieldDouble) > 0 {
 		dataLen := len(m.FieldDouble) * 8
@@ -1576,6 +1585,9 @@ func (m *AllRepeatedScalars) Size() int {
 }
 
 func (m *OneofVariants) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	switch v := m.Value.(type) {
 	case *OneofVariants_DoubleValue:
@@ -1622,6 +1634,9 @@ func (m *OneofVariants) Size() int {
 }
 
 func (m *Outer) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Middle.Size()
@@ -1642,6 +1657,9 @@ func (m *Outer) Size() int {
 }
 
 func (m *Middle) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Inner.Size()
@@ -1662,6 +1680,9 @@ func (m *Middle) Size() int {
 }
 
 func (m *Inner) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Data) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Data))) + len(m.Data)
@@ -1679,6 +1700,9 @@ func (m *Inner) Size() int {
 }
 
 func (m *HighFieldNumbers) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if len(m.Field1) > 0 {
 		n += 1 + protowire.SizeVarint(uint64(len(m.Field1))) + len(m.Field1)
@@ -1699,6 +1723,9 @@ func (m *HighFieldNumbers) Size() int {
 }
 
 func (m *WithEnum) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	if m.Color != 0 {
 		n += 1 + protowire.SizeVarint(uint64(m.Color))
@@ -1714,11 +1741,17 @@ func (m *WithEnum) Size() int {
 }
 
 func (m *Empty) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	return n
 }
 
 func (m *OnlyRepeated) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for _, v := range m.Names {
 		n += 1 + protowire.SizeVarint(uint64(len(v))) + len(v)
@@ -1738,6 +1771,9 @@ func (m *OnlyRepeated) Size() int {
 }
 
 func (m *Container) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	{
 		s := m.Variant.Size()
@@ -1763,6 +1799,9 @@ func (m *Container) Size() int {
 }
 
 func (m *AllMaps) Size() int {
+	if m == nil {
+		return 0
+	}
 	var n int
 	for k, v := range m.MapInt32Int32 {
 		entrySize := 0
@@ -1871,6 +1910,9 @@ func (m *AllMaps) Size() int {
 }
 
 func (m *AllScalars) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1884,11 +1926,17 @@ func (m *AllScalars) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AllScalars) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *AllScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.FieldBytes) > 0 {
 		i -= len(m.FieldBytes)
@@ -1984,6 +2032,9 @@ func (m *AllScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *AllOptionalScalars) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -1997,11 +2048,17 @@ func (m *AllOptionalScalars) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AllOptionalScalars) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *AllOptionalScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.FieldBytes != nil {
 		i -= len(m.FieldBytes)
@@ -2099,6 +2156,9 @@ func (m *AllOptionalScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *AllRepeatedScalars) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2112,11 +2172,17 @@ func (m *AllRepeatedScalars) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AllRepeatedScalars) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *AllRepeatedScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.FieldBytes) - 1; iNdEx >= 0; iNdEx-- {
 		i -= len(m.FieldBytes[iNdEx])
@@ -2265,6 +2331,9 @@ func (m *AllRepeatedScalars) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *OneofVariants) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2278,11 +2347,17 @@ func (m *OneofVariants) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *OneofVariants) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *OneofVariants) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	switch v := m.Value.(type) {
 	case *OneofVariants_BytesValue:
@@ -2365,6 +2440,9 @@ func (m *OneofVariants) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Outer) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2378,11 +2456,17 @@ func (m *Outer) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Outer) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Outer) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Name) > 0 {
 		i -= len(m.Name)
@@ -2422,6 +2506,9 @@ func (m *Outer) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Middle) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2435,11 +2522,17 @@ func (m *Middle) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Middle) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Middle) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.Value != 0 {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Value))
@@ -2477,6 +2570,9 @@ func (m *Middle) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Inner) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2490,11 +2586,17 @@ func (m *Inner) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Inner) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Inner) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if m.FixedVal != 0 {
 		i -= 4
@@ -2525,6 +2627,9 @@ func (m *Inner) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *HighFieldNumbers) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2538,11 +2643,17 @@ func (m *HighFieldNumbers) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *HighFieldNumbers) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *HighFieldNumbers) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Field16384) > 0 {
 		i -= len(m.Field16384)
@@ -2595,6 +2706,9 @@ func (m *HighFieldNumbers) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *WithEnum) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2608,11 +2722,17 @@ func (m *WithEnum) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *WithEnum) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *WithEnum) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	if len(m.Colors) > 0 {
 		var j int
@@ -2633,6 +2753,9 @@ func (m *WithEnum) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Empty) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2646,16 +2769,25 @@ func (m *Empty) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Empty) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Empty) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	return len(dAtA) - i, nil
 }
 
 func (m *OnlyRepeated) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2669,11 +2801,17 @@ func (m *OnlyRepeated) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *OnlyRepeated) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *OnlyRepeated) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.Items) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.Items[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -2706,6 +2844,9 @@ func (m *OnlyRepeated) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Container) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2719,11 +2860,17 @@ func (m *Container) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Container) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Container) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for iNdEx := len(m.Variants) - 1; iNdEx >= 0; iNdEx-- {
 		size, err := m.Variants[iNdEx].MarshalToSizedBuffer(dAtA[:i])
@@ -2773,6 +2920,9 @@ func (m *Container) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *AllMaps) Marshal() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
 	size := m.Size()
 	dAtA = make([]byte, size)
 	if size == 0 {
@@ -2786,11 +2936,17 @@ func (m *AllMaps) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AllMaps) MarshalTo(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *AllMaps) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
 	i := len(dAtA)
 	for k, v := range m.MapStringEnum {
 		baseI := i

--- a/test/basic/getter_reset_test.go
+++ b/test/basic/getter_reset_test.go
@@ -46,6 +46,46 @@ func TestReset_NilReceiver(t *testing.T) {
 	assert.NotPanics(t, func() { o.Reset() })
 }
 
+// Size and the Marshal family must be nil-safe to match the contract pinned by
+// Get*/Has*/Equal/Reset/String. CLAUDE.md "nil-safety on all generated receiver
+// methods" treats the surface as uniform; a nil panic from Size() while Get()
+// returns zero would surprise callers.
+func TestSize_NilReceiver(t *testing.T) {
+	var m *ks.AllScalars
+	assert.Equal(t, 0, m.Size())
+
+	var o *ks.Outer
+	assert.Equal(t, 0, o.Size())
+}
+
+func TestMarshal_NilReceiver(t *testing.T) {
+	var m *ks.AllScalars
+	b, err := m.Marshal()
+	assert.NoError(t, err)
+	assert.Nil(t, b)
+
+	var o *ks.Outer
+	b, err = o.Marshal()
+	assert.NoError(t, err)
+	assert.Nil(t, b)
+}
+
+func TestMarshalTo_NilReceiver(t *testing.T) {
+	var m *ks.AllScalars
+	buf := make([]byte, 16)
+	n, err := m.MarshalTo(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestMarshalToSizedBuffer_NilReceiver(t *testing.T) {
+	var m *ks.AllScalars
+	buf := make([]byte, 16)
+	n, err := m.MarshalToSizedBuffer(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
 func TestReset_NestedMessage(t *testing.T) {
 	msg := &ks.Outer{
 		Middle: ks.Middle{Value: 99, Inner: ks.Inner{Data: "deep"}},


### PR DESCRIPTION
## Summary

Generated `Size`, `Marshal`, `MarshalTo`, and `MarshalToSizedBuffer` now early-return zero values on a nil receiver instead of dereferencing and panicking. This aligns the marshal/size surface with the rest of the pointer-receiver API (`Reset`, `String`, `Get*`, `Has*`, `Equal`), which `CLAUDE.md` "Common review caveats" already requires to be nil-safe.

- `Size()` returns `0`.
- `Marshal()` returns `(nil, nil)`.
- `MarshalTo()` / `MarshalToSizedBuffer()` return `(0, nil)`.

Adds focused tests pinning the new contract for each method. Regenerates all `gen/**/*.pb.go` to pick up the new emit template.

Closes [wiresmith-2ma](https://github.com/grafana/wiresmith/issues?q=is%3Aopen+is%3Aissue+wiresmith-2ma) (CR-6).

## Performance

The Marshal/Size hot path picks up one un-taken branch per call. Benchstat against a clean baseline (`bench/...:_Ours$`, `count=20 benchtime=1s`, after thermal warmup):

| Benchmark             | Δ vs base |
| --------------------- | --------- |
| MarshalTraces_Ours    | +1.94%    |
| MarshalSingleSpan_Ours| +1.57%    |
| MarshalHistogram_Ours | +2.10%    |
| MarshalSummary_Ours   | +2.60%    |
| MarshalGauge_Ours     | +0.43%    |
| SizeTraces_Ours       | +4.28%    |
| SizeMap_Ours          | -0.98%    |
| Unmarshal_Ours (any)  | ±2% (noise — untouched by this change) |

The cost is real but small (~+2% geomean on Marshal/Size). The alternative (documenting Size/Marshal as nil-unsafe outliers) is worse for callers who already assume the rest of the API is uniformly nil-safe.

## Test plan

- [x] `go test ./compiler/... ./test/basic/`
- [x] `go vet ./...` and `go build ./...`
- [x] New tests cover `Size`, `Marshal`, `MarshalTo`, `MarshalToSizedBuffer` on `nil` for both flat (`AllScalars`) and nested (`Outer`) messages — verified passing.
- [x] `TestGenerateMatchesCheckedIn` passes after `make generate-ours`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)