### PR TITLE
fix: honor -M override for transitive imports in scoped runs

### DIFF
--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -792,7 +792,21 @@ func (g *Generator) computeDests(results []protoreflect.FileDescriptor) error {
 			continue
 		}
 		if !inResults[fd.Path()] {
-			g.destinations[fd.Path()] = destForReachable(fd)
+			// A -M override is an explicit "this file's Go code lives here"
+			// instruction keyed by fd.Path(); it must win even when the file
+			// enters only as a transitive import of a scoped (positional)
+			// root. destForReachable resolves purely from the file's own
+			// go_package and would silently drop the override — it exists to
+			// bypass the shared g.goPackages table for well-known types that
+			// share one proto package across many Go destinations, a concern
+			// that doesn't apply to an explicitly pinned path. destFor →
+			// destForPath checks g.Overrides first (keyed by fd.Path()), so
+			// the goPackages table is never consulted for the pinned file.
+			if override, ok := g.Overrides[fd.Path()]; ok && override != "" {
+				g.destinations[fd.Path()] = g.destFor(fd)
+			} else {
+				g.destinations[fd.Path()] = destForReachable(fd)
+			}
 			continue
 		}
 		// Files in results but excluded from emission (positional Files

--- a/compiler/generator/generator_test.go
+++ b/compiler/generator/generator_test.go
@@ -1739,11 +1739,11 @@ message Bar { vendored.a.Foo foo = 1; }`)
 	}
 }
 
-// TestGenerateScopedMOverrideTransitiveImport is a FAILING regression test for
-// the P2 bug: a scoped (positional-file) generation run ignores a -M override
-// when the overridden file is reached only as a TRANSITIVE IMPORT of the
-// positional root, so the emitted cross-file reference uses the dep's own
-// go_package instead of the override.
+// TestGenerateScopedMOverrideTransitiveImport is a regression test for the P2 bug:
+// a scoped (positional-file) generation run must honor a -M override even when
+// the overridden file is reached only as a transitive import of the positional
+// root, so the emitted cross-file reference uses the override (not the dep's
+// own go_package).
 //
 // ─── How to reproduce on the CLI ────────────────────────────────────────────
 //

--- a/compiler/generator/generator_test.go
+++ b/compiler/generator/generator_test.go
@@ -1739,6 +1739,125 @@ message Bar { vendored.a.Foo foo = 1; }`)
 	}
 }
 
+// TestGenerateScopedMOverrideTransitiveImport is a FAILING regression test for
+// the P2 bug: a scoped (positional-file) generation run ignores a -M override
+// when the overridden file is reached only as a TRANSITIVE IMPORT of the
+// positional root, so the emitted cross-file reference uses the dep's own
+// go_package instead of the override.
+//
+// ─── How to reproduce on the CLI ────────────────────────────────────────────
+//
+//	wiresmith -proto_path tree \
+//	  -M dep/dep.proto=example.com/OVERRIDE/dep \
+//	  tree/app/app.proto
+//
+// app.proto imports dep/dep.proto. The generated app.pb.go imports
+// "example.com/orig/dep" (dep.proto's own go_package) instead of the pinned
+// "example.com/OVERRIDE/dep". The -M flag — the user's explicit "this vendored
+// dep actually lives here" instruction — is silently dropped.
+//
+// ─── Why it happens ─────────────────────────────────────────────────────────
+//
+// In scoped mode (Generator.Files non-empty → emit set non-empty), compileSources
+// passes only the positional files (+ the embedded options schema) as the
+// protocompile roots:
+//
+//	roots = [<emit keys>..., embeddedOptionsPath]
+//	linked, _ := compiler.Compile(ctx, roots...)
+//	results = linked    // ← ONE FileDescriptor per requested root, NOT its deps
+//
+// protocompile.Compiler.Compile returns one linker.File per *requested* name;
+// transitive imports are linked into each root's .Imports() but are NOT
+// returned as their own top-level entries. So `results` (and therefore the
+// `inResults` set in computeDests) contains only the roots.
+//
+// computeDests then walks walkReachableFiles(results) — roots PLUS their
+// transitive imports — and for the transitive dep takes the !inResults branch:
+//
+//	if !inResults[fd.Path()] {
+//	    g.destinations[fd.Path()] = destForReachable(fd)   // ← bug
+//	    continue
+//	}
+//
+// destForReachable resolves purely from the file's own go_package option and
+// never consults g.Overrides — by design, because it must bypass the
+// g.goPackages table for well-known types (google.protobuf.* share one proto
+// package across many Go destinations). But that same blindness drops the -M
+// override for ordinary user deps.
+//
+// The non-scoped sibling TestGenerateWithMOverride PASSES because without
+// positional files every file in the walk is a compile root, so the dep IS in
+// `results`, takes the in-results branch, and resolves through g.destFor →
+// destForPath, which checks g.Overrides first.
+//
+// ─── Expected fix (not applied here — left for the implementer) ─────────────
+//
+// In the !inResults branch, route -M-pinned deps through the override-aware
+// path while keeping destForReachable for everything else (so the well-known-
+// type special case is preserved):
+//
+//	if !inResults[fd.Path()] {
+//	    if override, ok := g.Overrides[fd.Path()]; ok && override != "" {
+//	        g.destinations[fd.Path()] = g.destFor(fd)   // override wins
+//	    } else {
+//	        g.destinations[fd.Path()] = destForReachable(fd)
+//	    }
+//	    continue
+//	}
+//
+// destFor → destForPath returns the override immediately (keyed by fd.Path()),
+// so the g.goPackages table that destForReachable avoids is never consulted for
+// the pinned file — the well-known-type concern doesn't apply to an explicitly
+// overridden path.
+//
+// This test fails until that fix lands.
+func TestGenerateScopedMOverrideTransitiveImport(t *testing.T) {
+	protoDir := t.TempDir()
+	// a.proto declares an "external" go_package; the -M override should
+	// redirect references to it back into the consumer's tree.
+	writeProto(t, protoDir, "vendored/a/a.proto", `
+syntax = "proto3";
+package vendored.a;
+option go_package = "go.example.com/upstream/a";
+message Foo { string name = 1; }`)
+	// b.proto is the positional root; a.proto enters only as its transitive
+	// import (so a.proto is NOT in `results`).
+	writeProto(t, protoDir, "b/b.proto", `
+syntax = "proto3";
+package myapp.b;
+option go_package = "example.com/mod/gen/b";
+import "vendored/a/a.proto";
+message Bar { vendored.a.Foo foo = 1; }`)
+
+	outDir := testOutDir(t)
+	gen := &Generator{
+		Module:    "example.com/mod",
+		OutDir:    outDir,
+		ProtoDirs: []string{protoDir},
+		// Scoped run: only b.proto is a positional root.
+		Files: []string{filepath.Join(protoDir, "b", "b.proto")},
+		Overrides: map[string]string{
+			"vendored/a/a.proto": "example.com/mod/gen/a;aliased",
+		},
+	}
+	if err := gen.Generate(context.Background()); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	bContent, err := os.ReadFile(filepath.Join(outDir, "b", "b.pb.go"))
+	if err != nil {
+		t.Fatalf("b.pb.go: %v", err)
+	}
+	// The cross-file import in b.pb.go must use the override's import path even
+	// though a.proto was reached only as a transitive import of the scoped root.
+	if !strings.Contains(string(bContent), `"example.com/mod/gen/a"`) {
+		t.Errorf("scoped run dropped the -M override for a transitive import; b.pb.go should import the override path, got:\n%s", string(bContent))
+	}
+	if strings.Contains(string(bContent), `"go.example.com/upstream/a"`) {
+		t.Errorf("override ignored — b.pb.go still imports the upstream path (P2 bug):\n%s", string(bContent))
+	}
+}
+
 // TestGenerateGoPackageWithSemicolon verifies the semicolon form
 // "import/path;name" lets the proto author choose a Go package name that
 // differs from the last component of the import path.

--- a/compiler/generator/generator_test.go
+++ b/compiler/generator/generator_test.go
@@ -1790,27 +1790,12 @@ message Bar { vendored.a.Foo foo = 1; }`)
 // `results`, takes the in-results branch, and resolves through g.destFor →
 // destForPath, which checks g.Overrides first.
 //
-// ─── Expected fix (not applied here — left for the implementer) ─────────────
+// ─── Fix ────────────────────────────────────────────────────────────────────
 //
-// In the !inResults branch, route -M-pinned deps through the override-aware
-// path while keeping destForReachable for everything else (so the well-known-
-// type special case is preserved):
-//
-//	if !inResults[fd.Path()] {
-//	    if override, ok := g.Overrides[fd.Path()]; ok && override != "" {
-//	        g.destinations[fd.Path()] = g.destFor(fd)   // override wins
-//	    } else {
-//	        g.destinations[fd.Path()] = destForReachable(fd)
-//	    }
-//	    continue
-//	}
-//
-// destFor → destForPath returns the override immediately (keyed by fd.Path()),
-// so the g.goPackages table that destForReachable avoids is never consulted for
-// the pinned file — the well-known-type concern doesn't apply to an explicitly
-// overridden path.
-//
-// This test fails until that fix lands.
+// computeDests must consult g.Overrides even for transitively imported files in
+// scoped runs. Pinned files are routed through g.destFor (override-aware, keyed
+// by fd.Path()); everything else continues to use destForReachable to preserve
+// the well-known-type special case.
 func TestGenerateScopedMOverrideTransitiveImport(t *testing.T) {
 	protoDir := t.TempDir()
 	// a.proto declares an "external" go_package; the -M override should


### PR DESCRIPTION
## Summary

Fixes a P2 bug (`wiresmith-arym`): in a **scoped** generation run (positional files set, e.g. `wiresmith -proto_path tree -M dep/dep.proto=… tree/app/app.proto`), a `-M` override was silently dropped when the overridden file was reached only as a **transitive import** of the positional root. The emitted cross-file import used the dep's own `go_package` instead of the pinned override.

### Root cause
`computeDests` resolves a transitively-imported file (not in the compile `results`) via `destForReachable`, which reads only the file's own `go_package` and never consults `g.Overrides`. `destForReachable` exists to bypass the shared `g.goPackages` table for well-known types that share one proto package across many Go destinations — but that same blindness dropped the `-M` override for ordinary user deps.

The non-scoped path works because without positional files every reachable file is a compile root (in `results`), takes the in-results branch, and resolves through the override-aware `destFor` → `destForPath`.

### Fix
In the `!inResults` branch, route `-M`-pinned deps through `destFor` (override-aware, keyed by `fd.Path()`), keeping `destForReachable` for everything else so the well-known-type special case is preserved. The `goPackages` table is never consulted for the pinned file, so the well-known-type concern doesn't apply.

## Test plan
- New regression test `TestGenerateScopedMOverrideTransitiveImport` — fails before the fix, passes after.
- All existing override / `go_package` resolution tests pass.
- `go test ./compiler/...` green (incl. `TestGenerateMatchesCheckedIn`).

No marshal/unmarshal/size hot-path code changed — only the import-path string emitted for overridden deps — so no benchmark is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)