### PR TITLE
ci: harden bench workflow (persist-credentials, timeout)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,10 +16,13 @@ jobs:
   bench:
     name: Run Benchmarks
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod


### PR DESCRIPTION
Part of a post-public-release CI/security audit pass. `bench.yml` was the one workflow not matching the hardening already applied across `ci.yml`.

## Changes
- `persist-credentials: false` on `actions/checkout` — the bench job never pushes, so the checkout token is unnecessary (zizmor *artipacked*).
- `timeout-minutes: 15` on the bench job — every other job already sets a timeout; this prevents a hung benchmark from running indefinitely.

No behavioral change to the benchmarks themselves.

## Audit note (out of band, already applied via repo settings)
Alongside this PR, the following repo settings were hardened directly:
- Default `GITHUB_TOKEN` permissions: `write` → `read`, and disabled "Allow GitHub Actions to approve pull requests" (every workflow already declares its own `permissions:`).
- Enabled CodeQL default setup (`go` + `actions`, extended query suite).
- Added `Lint` and `Generated Code` to the `main` required-status-checks ruleset (previously enforced only transitively via `needs:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)