### PR TITLE
fix(deps): revert vtprotobuf digest bump (#151) — restore go 1.25.0, unbreak main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/bufbuild/protocompile v0.14.1
 	github.com/gogo/protobuf v1.3.2
-	github.com/planetscale/vtprotobuf v0.6.1-0.20260702190614-8ae5a48058df
+	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/pdata v1.61.0
 	go.opentelemetry.io/proto/otlp v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/planetscale/vtprotobuf v0.6.1-0.20260702190614-8ae5a48058df h1:x2ymdov8jnZLDPfI+VVcf/ZvzuZ2u36ieXTuQASMkWI=
-github.com/planetscale/vtprotobuf v0.6.1-0.20260702190614-8ae5a48058df/go.mod h1:araspv2uYKozbi5lrKaqpv1/Uei7eQSml8JCw2A3IRg=
+github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 h1:S1hI5JiKP7883xBzZAr1ydcxrKNSVNm7+3+JwjxZEsg=
+github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25/go.mod h1:ZQntvDG8TkPgljxtA0R9frDoND4QORU1VXz015N5Ks4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=


### PR DESCRIPTION
## Problem

`main` is red — `Lint` and `Benchmarks` fail, and `go build ./...` reports `updates to go.mod needed`.

Root cause: Renovate #151 bumped the **benchmark-only** dependency `github.com/planetscale/vtprotobuf` to digest `8ae5a48`, whose own `go.mod` requires **go 1.26.4**. wiresmith pins **go 1.25.0**, and Go's forward-compatibility rule forbids depending on a module that requires a newer Go than you declare, so the module graph became inconsistent:

- `Lint` → `no go files to analyze: running go mod tidy may solve the problem`
- `Benchmarks` → build failure
- `go build ./...` → `updates to go.mod needed`

It reached `main` because the branch ruleset uses `strict_required_status_checks_policy: false`, so #151 was never re-tested against the batch (#140 / #143 / #147 / #150) that merged alongside it — each PR was green in isolation, but their combination was not.

## Fix

Revert #151, pinning vtprotobuf back to the go-1.25-compatible digest `ba97887b0a25`. vtprotobuf is used only for benchmark comparison (`gen/vtpb`, `gen/bench/vtpb`; the `protohelpers` reference is an attribution comment, not an import). Nothing in the compiler or the importable runtime packages depends on it, so reverting keeps the public module's Go floor at 1.25.0 rather than raising the minimum Go version for all importers over a bench-only dependency.

## Verification

- `go build ./...` — clean
- `go mod tidy` — no-op (`go 1.25.0` retained)
- `go test ./compiler/...` — pass
- `bench` package — compiles and passes

## Follow-up (recommended, not in this PR)

Renovate will re-propose this vtprotobuf bump. To hold the `go 1.25.0` floor durably, add to `.github/renovate.json5`:

```json5
constraints: { go: '1.25.0' }
```

so Renovate skips dependency updates that require a newer Go. Can add here or as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
